### PR TITLE
Pa11y dashboard integration

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,0 +1,92 @@
+# Hosting BBC-A11y
+
+A convenient way of testing your web app's BBC Accessibility Standards
+compliance over time is to host an instance of
+[pa11y-dashboard](https://github.com/springernature/pa11y-dashboard).
+
+## Hosting pa11y-dashboard
+
+pa11y-dashboard is an open source accessibility dashboard that is used to
+automate testing of accessibility standards and track test results over time.
+It consists of two separate web apps:
+
+  * [pa11y-webservice](https://github.com/springernature/pa11y-webservice)
+    exposes a REST API for running standards checks using
+    [phantomjs](http://phantomjs.org/) and recording results in a
+    [mongo](https://www.mongodb.org/) database.
+
+  * [pa11y-dashboard](https://github.com/springernature/pa11y-dashboard) is
+    a front-end UI for exploring the results of accessibility
+    standards checks over time.
+
+The pa11y-dashboard app can be deployed either with an embedded
+pa11y-webservice, or independently. In the example below we deploy them as two
+separate heroku apps connected over the internet.
+
+## Example: Deploying to Heroku
+
+We've made a few tweaks to the pa11y apps to make it possible to deploy them to
+[12-factor](http://12factor.net/) hosting environments like
+[heroku](http://heroku.com). We're hoping these changes are merged into pa11y,
+but until then, you can deploy these forks of pa11y to heroku, specifically the
+`12-factor` branches, as follows:
+
+```
+git clone https://github.com/joshski/pa11y-webservice
+cd pa11y-webservice
+heroku create your-pa11y-webservice
+git push heroku 12-factor:master
+cd ..
+
+git clone https://github.com/joshski/pa11y-dashboard
+cd pa11y-dashboard
+heroku create your-pa11y-dashboard
+git push heroku 12-factor:master
+cd ..
+```
+
+With these two heroku apps deployed, you can connect the dashboard app
+to the web service app:
+
+```
+cd pa11y-dashboard
+heroku config:set WEBSERVICE_URL=https://your-pa11y-webservice.herokuapp.com/
+cd ..
+```
+(n.b. the trailing slash is important)
+
+Finally, you need to provision a mongodb database. In this example, I'm using
+[mLab](https://devcenter.heroku.com/articles/mongolab) (still known by heroku as
+`mongolab`):
+
+```
+cd pa11y-webservice
+heroku addons:create mongolab
+```
+
+This will set a new environment variable in heroku, exposing a mongodb
+database URL for your pa11y web service to connect to:
+
+```
+heroku config
+
+=== your-pa11y-webservice Config Vars
+MONGOLAB_URI: mongodb://your-mongodb-url
+```
+
+However, `pa11y-webservice` requires an environment variable called
+`DATABASE_URL`, so you need to copy the value of `MONGOLAB_URI`:
+
+```
+heroku config:set DATABASE_URL=mongodb://your-mongodb-url
+```
+
+Your dashboard should now be up and running at
+`http://your-pa11y-dashboard.herokuapp.com`. 
+
+If you want to allow registering new jobs via the web dashboard, you'll need to
+explicitly enable this:
+
+```
+heroku config:set READONLY=false
+```

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -26,22 +26,23 @@ separate heroku apps connected over the internet.
 ## Example: Deploying to Heroku
 
 We've made a few tweaks to the pa11y apps to make it possible to deploy them to
-[12-factor](http://12factor.net/) hosting environments like
+[12 factor](http://12factor.net/) hosting environments like
 [heroku](http://heroku.com). We're hoping these changes are merged into pa11y,
 but until then, you can deploy these forks of pa11y to heroku, specifically the
-`12-factor` branches, as follows:
+`bbc-a11y` branches, like this:
 
 ```
 git clone https://github.com/joshski/pa11y-webservice
 cd pa11y-webservice
 heroku create your-pa11y-webservice
-git push heroku 12-factor:master
+heroku buildpacks:set https://github.com/datamail/heroku-buildpack-nodejs-phantomjs.git
+git push heroku bbc-a11y:master
 cd ..
 
 git clone https://github.com/joshski/pa11y-dashboard
 cd pa11y-dashboard
 heroku create your-pa11y-dashboard
-git push heroku 12-factor:master
+git push heroku bbc-a11y:master
 cd ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ project today.
 The [getting started guide](GETTINGSTARTED.md) shows how to use a11y in your
 project.
 
+## Hosting an Accessibility Metrics Dashboard
+
+The [hosting guide](HOSTING.md) includes an example of deploying an interactive
+dashboard web app for tracking accessibility metrics over time.
+
 ## Contributing to BBC A11y
 
 We welcome contributions of ideas and code! Please refer to the

--- a/lib/bbc/a11y/js/standards.js
+++ b/lib/bbc/a11y/js/standards.js
@@ -62,6 +62,30 @@ for (var section in Standards.sections) {
   }
 }
 
+Standards.json = function() {
+  var standards = [];
+  for (var section in Standards.sections) {
+    for (var i = 0; i < Standards.sections[section].length; ++i) {
+      var standard = Standards.sections[section][i];
+      standards.push({
+        name: 'BBCA11y.' + section + '.' + camelise(standard.name),
+        description: standard.name
+      })
+    }
+  }
+  return JSON.stringify({
+    name: 'BBC.A11y',
+    rules: standards
+  }, null, 2);
+}
+
+function camelise(str) {
+  return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
+    if (+match === 0) return "";
+    return index == 0 ? match.toLowerCase() : match.toUpperCase();
+  });
+}
+
 Standards.prototype.validate = function(jquery) {
   var results = [];
   var standardResult;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "karma start --single-run --browsers PhantomJS",
     "browserify": "browserify ./lib/bbc/a11y/js/a11y.js -o ./lib/bbc/a11y/js/bundle.js",
-    "watchify": "watchify ./lib/bbc/a11y/js/a11y.js -o ./lib/bbc/a11y/js/bundle.js"
+    "watchify": "watchify ./lib/bbc/a11y/js/a11y.js -o ./lib/bbc/a11y/js/bundle.js",
+    "standards-json": "node -e \"console.log(require('./lib/bbc/a11y/js/standards').json())\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is mostly documentation about how to deploy a special version of pa11y dashboard and web services to heroku, (with bbc-a11y standards checks included). Here's an example of a deployed dashboard:

http://a11y-pa11y-dashboard.herokuapp.com/
