### PR TITLE
Use fully qualified standard names everywhere

### DIFF
--- a/GETTINGSTARTED.md
+++ b/GETTINGSTARTED.md
@@ -41,7 +41,7 @@ checks.
 
 ```
 page "http://bbc.co.uk" do
-  skip_standard 'anchors must have hrefs'
+  skip_standard 'Focusable controls: Anchors must have hrefs'
 end
 
 page "http://bbc.co.uk/news"

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ Bundler::GemHelper.install_tasks
 task default: [:unit, :acceptance]
 
 task :unit do
-  sh "bundle exec rspec"
+  sh "bundle exec rspec && karma start --single-run"
 end
 
 task :acceptance do

--- a/a11y.rb
+++ b/a11y.rb
@@ -1,5 +1,3 @@
 page "https://bbc.co.uk/news" do
-  skip_standard /W3C/
-  skip_standard /JavaScript/
-  skip_standard /title/
+  skip_standard /title/i
 end

--- a/features/check_standards/04_indicating_language.feature
+++ b/features/check_standards/04_indicating_language.feature
@@ -23,7 +23,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the "html must have lang attribute" standard
+    When I validate the "Indicating language: html must have lang attribute" standard
     Then it passes
 
   Scenario: Missing lang attribute on html element
@@ -39,7 +39,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the "html must have lang attribute" standard
+    When I validate the "Indicating language: html must have lang attribute" standard
     Then it fails with the message:
       """
       html tag has no lang attribute: /html

--- a/features/check_standards/06_main_landmark.feature
+++ b/features/check_standards/06_main_landmark.feature
@@ -12,7 +12,7 @@ Feature: Main landmark
       """
       <div role="main">Main element</div>
       """
-    When I validate the "exactly one main landmark" standard
+    When I validate the "Main landmark: exactly one main landmark" standard
     Then it passes
 
   Scenario: Page has two main elements
@@ -21,7 +21,7 @@ Feature: Main landmark
       <div role="main">Main one</div>
       <div role="main">Main two</div>
       """
-    When I validate the "exactly one main landmark" standard
+    When I validate the "Main landmark: exactly one main landmark" standard
     Then it fails with the message:
       """
       Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
@@ -32,7 +32,7 @@ Feature: Main landmark
       """
       <div role="not-main">Main one</div>
       """
-    When I validate the "exactly one main landmark" standard
+    When I validate the "Main landmark: exactly one main landmark" standard
     Then it fails with the message:
       """
       Found 0 elements with role="main".

--- a/features/check_standards/07_headings.feature
+++ b/features/check_standards/07_headings.feature
@@ -23,7 +23,7 @@ Feature: Headings
       """
       <h2>Heading 2</h2>
       """
-    When I validate the "exactly one main heading" standard
+    When I validate the "Headings: exactly one main heading" standard
     Then it fails with the message:
       """
       Found 0 h1 elements.
@@ -36,7 +36,7 @@ Feature: Headings
       <h2>Heading 2</h2>
       <h1>Heading 1</h1>
       """
-    When I validate the "exactly one main heading" standard
+    When I validate the "Headings: exactly one main heading" standard
     Then it fails with the message:
       """
       Found 2 h1 elements: /html/body/h1[1] /html/body/h1[2]
@@ -48,7 +48,7 @@ Feature: Headings
       <h1>A Heading</h1>
       <h1 style="display:none">Another Heading</h1>
       """
-    When I validate the "exactly one main heading" standard
+    When I validate the "Headings: exactly one main heading" standard
     Then it passes
 
   Scenario: Headings in ascending order
@@ -61,7 +61,7 @@ Feature: Headings
       <h5>Heading 5</h5>
       <h6>Heading 6</h6>
       """
-    When I validate the "headings must be in ascending order" standard
+    When I validate the "Headings: headings must be in ascending order" standard
     Then it passes
 
   Scenario: Headings in invalid order
@@ -71,7 +71,7 @@ Feature: Headings
       <h3>Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the "headings must be in ascending order" standard
+    When I validate the "Headings: headings must be in ascending order" standard
     Then it fails with the message:
       """
       Headings are not in order: /html/body/h1 /html/body/h3
@@ -87,7 +87,7 @@ Feature: Headings
       <h2>Heading 2b</h2>
       <h3>Heading 3b</h3>
       """
-    When I validate the "headings must be in ascending order" standard
+    When I validate the "Headings: headings must be in ascending order" standard
     Then it passes
 
   Scenario: Heading is hidden
@@ -97,7 +97,7 @@ Feature: Headings
       <h3 style="display:none">Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the "headings must be in ascending order" standard
+    When I validate the "Headings: headings must be in ascending order" standard
     Then it fails with the message:
       """
       Headings are not in order: /html/body/h1 /html/body/h3
@@ -112,7 +112,7 @@ Feature: Headings
       </script>
       <h2>Heading 2</h2>
       """
-    When I validate the "headings must be in ascending order" standard
+    When I validate the "Headings: headings must be in ascending order" standard
     Then it passes
 
   Scenario: Subheading before the first main heading
@@ -122,7 +122,7 @@ Feature: Headings
       <h1>Heading 1</h1>
       <h2>Heading 2</h2>
       """
-    When I validate the "headings must be in ascending order" standard
+    When I validate the "Headings: headings must be in ascending order" standard
     Then it passes
 
   Scenario: Content between headings
@@ -141,7 +141,7 @@ Feature: Headings
         non-heading content
       </div>
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it passes
 
   Scenario: Heading followed by subheading
@@ -151,7 +151,7 @@ Feature: Headings
       <h2>Another heading</h2>
       <p>...and some content</p>
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it passes
 
   Scenario: No content between headings
@@ -165,7 +165,7 @@ Feature: Headings
         <p>non-heading content</p>
       </div>
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it fails with the message:
       """
       No content follows: /html/body/div/h2[1]
@@ -179,7 +179,7 @@ Feature: Headings
       </div>
       Followed by some content
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it passes
   
   Scenario: Nested heading followed by heading
@@ -190,7 +190,7 @@ Feature: Headings
       </div>
       <h1>Another heading</h1>
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it fails with the message:
       """
       No content follows: /html/body/div/h1
@@ -207,7 +207,7 @@ Feature: Headings
         Followed by some content
       </div>
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it passes
 
   Scenario: Non-nested heading followed by nested content
@@ -218,5 +218,5 @@ Feature: Headings
         Followed by some content
       </div>
       """
-    When I validate the "content must follow headings" standard
+    When I validate the "Headings: content must follow headings" standard
     Then it passes

--- a/features/check_standards/08_minimum_text_size.feature
+++ b/features/check_standards/08_minimum_text_size.feature
@@ -26,7 +26,7 @@ Feature: Minimum text size
       </style>
       <span>Some text</span> with <span>more <b>text</b> also</span>.
       """
-    When I validate the "minimum text size" standard
+    When I validate the "Minimum text size: text cannot be too small" standard
     Then it fails with the message:
       """
       Text size too small (10px): /html/body
@@ -43,7 +43,7 @@ Feature: Minimum text size
         </style>
         <span style="font-size: 1px">Tiny text, but it's hidden!</span>
         """
-      When I validate the "minimum text size" standard
+      When I validate the "Minimum text size: text cannot be too small" standard
       Then it passes
 
     Scenario: Text nodes with only whitespace
@@ -52,5 +52,5 @@ Feature: Minimum text size
         <div id="blq-global" style="font-size: 1px"> <div id="blq-pre-mast">  </div> &nbsp;
         </div>
         """
-      When I validate the "minimum text size" standard
+      When I validate the "Minimum text size: text cannot be too small" standard
       Then it passes

--- a/features/check_standards/10_tab_index.feature
+++ b/features/check_standards/10_tab_index.feature
@@ -24,7 +24,7 @@ Feature: Tab Index
       <button type="submit">Search</button>
       <div tabindex="-1"></div>
       """
-    When I validate the "elements with zero tab index must be fields" standard
+    When I validate the "Tab index: elements with zero tab index must be fields" standard
     Then it passes
 
   Scenario: Focusable elements with zero tab index
@@ -36,7 +36,7 @@ Feature: Tab Index
       <select tabindex="0"></select>
       <textarea tabindex="0"></textarea>
       """
-    When I validate the "elements with zero tab index must be fields" standard
+    When I validate the "Tab index: elements with zero tab index must be fields" standard
     Then it passes
 
   Scenario: Unfocusable element with zero tab index
@@ -47,7 +47,7 @@ Feature: Tab Index
       <div tabindex="3"></div>
       <div tabindex="0"></div>
       """
-    When I validate the "elements with zero tab index must be fields" standard
+    When I validate the "Tab index: elements with zero tab index must be fields" standard
     Then it fails with the message:
       """
       Non-field element with tabindex=0: /html/body/div[2]

--- a/features/check_standards/11_title_attributes.feature
+++ b/features/check_standards/11_title_attributes.feature
@@ -23,7 +23,7 @@ Feature: Title Attributes
         <img src="close.png" />
       </button>
       """
-    When I validate the "title attributes only on inputs" standard
+    When I validate the "Title attributes: title attributes only on inputs" standard
     Then it passes
 
   Scenario: Hidden element with title attribute
@@ -31,7 +31,7 @@ Feature: Title Attributes
       """
       <iframe style="display:none" title="Ignore me, I'm invisible"></iframe>
       """
-    When I validate the "title attributes only on inputs" standard
+    When I validate the "Title attributes: title attributes only on inputs" standard
     Then it passes
 
   Scenario: Anchor tag with title attribute
@@ -41,7 +41,7 @@ Feature: Title Attributes
         <img src="close.png" />
       </a>
       """
-    When I validate the "title attributes only on inputs" standard
+    When I validate the "Title attributes: title attributes only on inputs" standard
     Then it fails with the message:
       """
       Non-input element has title attribute: /html/body/a

--- a/features/check_standards/12_focusable_controls.feature
+++ b/features/check_standards/12_focusable_controls.feature
@@ -42,7 +42,7 @@ Feature: Focusable Controls
           <li><a href="#entertainmenttab">Entertainment</a></li>
       </ul>
       """
-    When I validate the "anchors must have hrefs" standard
+    When I validate the "Focusable controls: anchors must have hrefs" standard
     Then it passes
 
   Scenario: Some anchor tags do not have href attributes
@@ -54,7 +54,7 @@ Feature: Focusable Controls
           <li><a>Entertainment</a></li>
       </ul>
       """
-    When I validate the "anchors must have hrefs" standard
+    When I validate the "Focusable controls: anchors must have hrefs" standard
     Then it fails with the message:
       """
       Anchor has no href attribute: /html/body/ul/li[1]/a

--- a/features/check_standards/18_image_alternatives.feature
+++ b/features/check_standards/18_image_alternatives.feature
@@ -23,7 +23,7 @@ Feature: Image Alternatives
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" alt="" />
       """
-    When I validate the "images must have alt attributes" standard
+    When I validate the "Image alternatives: images must have alt attributes" standard
     Then it passes
 
   Scenario: Images without alt attributes
@@ -32,7 +32,7 @@ Feature: Image Alternatives
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" />
       """
-    When I validate the "images must have alt attributes" standard
+    When I validate the "Image alternatives: images must have alt attributes" standard
     Then it fails with the message:
       """
       Image has no alt attribute: /html/body/img[2]

--- a/features/check_standards/19_form_labels.feature
+++ b/features/check_standards/19_form_labels.feature
@@ -29,7 +29,7 @@ Feature: Form Labels
 
       <input type="text" name="q" title="Search the BBC" />
       """
-    When I validate the "fields must have labels or titles" standard
+    When I validate the "Form labels: fields must have labels or titles" standard
     Then it passes
 
   Scenario: Some fields without labels or title attributes
@@ -44,7 +44,7 @@ Feature: Form Labels
       <input type="text" name="q" aria-label="Search the BBC" />
       <input type="text" name="q" placeholder="Search the BBC" />
       """
-    When I validate the "fields must have labels or titles" standard
+    When I validate the "Form labels: fields must have labels or titles" standard
     Then it fails with the message:
       """
       Field has no label or title attribute: /html/body/textarea
@@ -60,5 +60,5 @@ Feature: Form Labels
       """
       <input type=hidden name=a value=b>
       """
-    When I validate the "fields must have labels or titles" standard
+    When I validate the "Form labels: fields must have labels or titles" standard
     Then it passes

--- a/features/check_standards/20_form_interactions.feature
+++ b/features/check_standards/20_form_interactions.feature
@@ -27,7 +27,7 @@ Feature: Form Interactions
         <input type="submit" value="Search">
       </form>
       """
-    When I validate the "forms must have submit buttons" standard
+    When I validate the "Form interactions: forms must have submit buttons" standard
     Then it passes
 
   Scenario: Form with no submit button
@@ -38,7 +38,7 @@ Feature: Form Interactions
         <input type="text" name="q" id="q">
       </form>
       """
-    When I validate the "forms must have submit buttons" standard
+    When I validate the "Form interactions: forms must have submit buttons" standard
     Then it fails with the message:
       """
       Form has no submit button: /html/body/form
@@ -52,5 +52,5 @@ Feature: Form Interactions
         <button type="submit">Search</button>
       </form>
       """
-    When I validate the "forms must have submit buttons" standard
+    When I validate the "Form interactions: forms must have submit buttons" standard
     Then it passes

--- a/features/cli/display_result_summary.feature
+++ b/features/cli/display_result_summary.feature
@@ -7,7 +7,7 @@ Feature: Display result summary
       page "http://localhost:54321/perfect.html"
       page "http://localhost:54321/missing_header.html"
       page "http://localhost:54321/missing_header.html?again!" do
-        skip_standard "exactly one main heading"
+        skip_standard "Headings: exactly one main heading"
       end
       """
     When I run `a11y`

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -5,7 +5,7 @@ Feature: Skipping Standards
     And a file named "a11y.rb" with:
       """
       page "http://localhost:54321/missing_header.html" do
-        skip_standard "exactly one main heading"
+        skip_standard "Headings: exactly one main heading"
       end
       """
     When I run `a11y`

--- a/features/mute_errors.feature
+++ b/features/mute_errors.feature
@@ -16,7 +16,7 @@ Feature: Mute errors
       """
       <p>yo</p>
       """
-    When I validate the "exactly one main heading" standard
+    When I validate the "Headings: exactly one main heading" standard
     Then it fails with the message:
       """
       Found 0 h1 elements.

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -36,9 +36,8 @@ When(/^I validate the \"([^\"]+)\" standard$/) do |standard_name|
   browser.execute_script(BBC::A11y::Javascript.bundle)
   validation = browser.evaluate_script("a11y.validate(#{standard_name.to_json})")
   if validation['results'].size != 1
-    raise "#{validation['results'].size} standards match '#{pattern}'"
+    raise "#{validation['results'].size} standards match '#{standard_name}' (expected 1 match)"
   end
-  puts validation['results'].inspect
   @result = BBC::A11y::LintResult.from_json(validation)
 end
 

--- a/lib/bbc/a11y/js/standards.js
+++ b/lib/bbc/a11y/js/standards.js
@@ -38,7 +38,7 @@ Standards.sections = {
   ],
 
   minimumTextSize: [
-    require('./standards/minimumTextSize/minimumTextSize')
+    require('./standards/minimumTextSize/textCannotBeTooSmall')
   ],
 
   tabIndex: [
@@ -96,15 +96,15 @@ Standards.matching = function(criteria) {
 function standardsMatching(criteria) {
   var skips = criteria.skip || [];
   for (var i = 0; i < skips.length; ++i) {
-    skips[i] = normalise(skips[i]);
+    skips[i] = normaliseStandardName(skips[i]);
   }
   var isOnly = typeof(criteria.only) == 'string';
-  var only = isOnly ? normalise(criteria.only) : null;
+  var only = isOnly ? normaliseStandardName(criteria.only) : null;
   var matches = [];
   var skipped = [];
   for (var i = 0; i < Standards.all.length; ++i) {
     var standard = Standards.all[i];
-    var name = normalise(standard.name);
+    var name = standard.section.toLowerCase() + normaliseStandardName(standard.name);
     if (isOnly) {
       if (only == name) {
         matches.push(standard);
@@ -120,8 +120,8 @@ function standardsMatching(criteria) {
   return { matches: matches, skipped: skipped };
 }
 
-function normalise(name) {
-  return name.replace(/\s+/g, '').toLowerCase();
+function normaliseStandardName(name) {
+  return name.replace(/\W+/g, '').toLowerCase();
 }
 
 module.exports = Standards;

--- a/lib/bbc/a11y/js/standards/minimumTextSize/textCannotBeTooSmall.js
+++ b/lib/bbc/a11y/js/standards/minimumTextSize/textCannotBeTooSmall.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'Minimum text size',
+  name: 'Text cannot be too small',
 
   validate: function($, fail) {
     var textNodes = $('*:not(head, script, style):visible').contents().filter(function() {

--- a/spec/bbc/a11y/js/a11ySpec.js
+++ b/spec/bbc/a11y/js/a11ySpec.js
@@ -45,7 +45,7 @@ describe('a11y', function() {
   });
 
   it('skips standards', function() {
-    var validation = a11y.validate({ skip: ['Exactly one main landmark'] });
+    var validation = a11y.validate({ skip: ['Main landmark: Exactly one main landmark'] });
     expect(validation.skipped).to.eql(['Exactly one main landmark']);
   });
 });

--- a/spec/bbc/a11y/js/minimumTextSizeStandardSpec.js
+++ b/spec/bbc/a11y/js/minimumTextSizeStandardSpec.js
@@ -1,4 +1,4 @@
-var standard = require('../../../../lib/bbc/a11y/js/standards/minimumTextSize/minimumTextSize');
+var standard = require('../../../../lib/bbc/a11y/js/standards/minimumTextSize/textCannotBeTooSmall');
 var $ = require('jquery');
 var expect = require('chai').expect;
 

--- a/spec/bbc/a11y/js/standardsSpec.js
+++ b/spec/bbc/a11y/js/standardsSpec.js
@@ -9,23 +9,23 @@ describe('standards', function() {
     });
   });
 
-  describe('.matching(string)', function() {
+  describe('.matching("Focusable Controls: Anchors must have hrefs")', function() {
     it('finds standards matching the string', function() {
-      var matches = standards.matching('anchors must have hrefs');
+      var matches = standards.matching('Focusable Controls: anchors must have hrefs');
       expect(matches.standards.length).to.equal(1);
     });
   });
 
-  describe('.matching({ skip: ["anchors must have hrefs"] })', function() {
+  describe('.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] })', function() {
     it('finds all standards except one', function() {
-      var matches = standards.matching({ skip: ["anchors must have hrefs"] });
+      var matches = standards.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] });
       expect(matches.standards.length).to.equal(standards.all.length - 1);
     });
   });
 
-  describe('.matching({ only: "anchors must have hrefs" })', function() {
+  describe('.matching({ only: "Focusable controls: Anchors must have hrefs" })', function() {
     it('finds one standard', function() {
-      var matches = standards.matching({ only: "anchors must have hrefs" });
+      var matches = standards.matching({ only: "Focusable controls: Anchors must have hrefs" });
       expect(matches.standards.length).to.equal(1);
     });
   });


### PR DESCRIPTION
When you run a11y, you now get output like this:

```
✗ https://bbc.co.uk/news
  * Form Interactions: Forms must have submit buttons
    - Form has no submit button: /html/body/div[2]/header/div/div[1]/div[3]/form
```

Skipping this standard was done like this:

```
skip_standard "Forms must have submit buttons"
```

This change means you have to use the "fully qualified" standard name to skip it, e.g.:

```
skip_standard "Form Interactions: Forms must have submit buttons"
```

I think it's better because it's easier to copy/paste from the test output into the configuration.
