### PR TITLE
Fixing Travis CI build error & updating README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rvm:
-  2.2
 before_script:
   - npm install
   - export PATH=$PWD/node_modules/.bin:$PATH

--- a/GETTINGSTARTED.md
+++ b/GETTINGSTARTED.md
@@ -17,7 +17,9 @@ then:
 
 Create or amend your your project's `Gemfile` to include this line:
 
-    gem 'bbc-a11y`
+    gem 'bbc-a11y'
+    
+    source 'https://rubygems.org'
 
 Now install the gem:
 


### PR DESCRIPTION
## Summary

As part of my PR I fixed the failing Travis CI build. Removed the :rvm key from `travis.yml` so that the `.ruby-version` file is respected: https://docs.travis-ci.com/user/languages/ruby#Using-.ruby-version

Also updated the docs specifying the gem source in the README for those who aren't familiar with rubygems & gemfiles otherwise you get an error on `bundle install`.
## Motivation and Context

Fixing the build prevents PRs which are failing 1/2 checks from being merged into master. 

The README change allows setting up bbc-a11y on a new project, which may not use Ruby already, a little bit easier when following the getting started docs.
