### PR TITLE
Relax form labels for submit/reset inputs, fixes #94

### DIFF
--- a/features/check_standards/19_form_labels.feature
+++ b/features/check_standards/19_form_labels.feature
@@ -78,6 +78,30 @@ Feature: Form Labels
     When I validate the "Form labels: fields must have labels or titles" standard
     Then it passes
 
+  Scenario: Submit inputs do not need labels or title attributes
+    Given a page with the body:
+      """
+      <input type="submit" />
+      """
+    When I validate the "Form labels: fields must have labels or titles" standard
+    Then it passes
+
+  Scenario: Reset inputs do not need labels or title attributes
+    Given a page with the body:
+      """
+      <input type="reset" />
+      """
+    When I validate the "Form labels: fields must have labels or titles" standard
+    Then it passes
+
+  Scenario: Image inputs do not need labels or title attributes
+    Given a page with the body:
+      """
+      <input type="image" />
+      """
+    When I validate the "Form labels: fields must have labels or titles" standard
+    Then it passes
+
   Scenario: Buttons do not need labels or title attributes
     Given a page with the body:
       """
@@ -85,3 +109,14 @@ Feature: Form Labels
       """
     When I validate the "Form labels: fields must have labels or titles" standard
     Then it passes
+
+  Scenario: Buttons need text
+    Given a page with the body:
+      """
+      <button></button>
+      """
+    When I validate the "Form labels: fields must have labels or titles" standard
+    Then it fails with the message:
+      """
+      Button has no text: /html/body/button
+      """

--- a/features/check_standards/19_form_labels.feature
+++ b/features/check_standards/19_form_labels.feature
@@ -54,7 +54,7 @@ Feature: Form Labels
       Field has no label or title attribute: /html/body/input[5]
       """
 
-  Scenario: Hidden fields do not need titles
+  Scenario: Hidden fields do not need labels or title attributes
     Given a page with the body:
       """
       <input type=hidden name=a value=b>
@@ -65,7 +65,23 @@ Feature: Form Labels
   Scenario: Submit buttons do not need title attributes or labels
     Given a page with the body:
       """
-      <input name="locator-submit" class="submit" type="submit" value="Search">
+      <input type=submit name=a value=b>
+      """
+    When I validate the "Form labels: fields must have labels or titles" standard
+    Then it passes
+
+  Scenario: Reset inputs do not need labels or title attributes
+    Given a page with the body:
+      """
+      <input type=reset name=a value=b>
+      """
+    When I validate the "Form labels: fields must have labels or titles" standard
+    Then it passes
+
+  Scenario: Buttons do not need labels or title attributes
+    Given a page with the body:
+      """
+      <button>Boo</button>
       """
     When I validate the "Form labels: fields must have labels or titles" standard
     Then it passes

--- a/lib/bbc/a11y/js/standards/formLabels/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/bbc/a11y/js/standards/formLabels/fieldsMustHaveLabelsOrTitles.js
@@ -15,7 +15,7 @@ module.exports = {
   name: 'Fields must have labels or titles',
 
   validate: function($, fail) {
-    $("input:not([type='hidden']):not([type='submit']):not([title]), " +
+    $("input:not([type='hidden'], [type='submit'], [type='reset'], [title]), " +
       "textarea:not([title]), " +
       "select:not([title])").each(function(index, field) {
       if (!hasIdOrLabel($(field))) {

--- a/lib/bbc/a11y/js/standards/formLabels/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/bbc/a11y/js/standards/formLabels/fieldsMustHaveLabelsOrTitles.js
@@ -15,12 +15,21 @@ module.exports = {
   name: 'Fields must have labels or titles',
 
   validate: function($, fail) {
-    $("input:not([type='hidden'], [type='submit'], [type='reset'], [title]), " +
-      "textarea:not([title]), " +
-      "select:not([title])").each(function(index, field) {
-      if (!hasIdOrLabel($(field))) {
-        fail('Field has no label or title attribute:', field)
-      }
-    });
+    $("input:not([title], [type='hidden'], [type='submit'], [type='reset'], [type='image']), " +
+      "textarea:not([title]), select:not([title])")
+      .filter(function(index, field) {
+        return !hasIdOrLabel($(field));
+      })
+      .each(function(index, element) {
+        fail('Field has no label or title attribute:', element)
+      });
+
+    $('button')
+      .filter(function(index, button) {
+        return $(button).text().trim() == '';
+      })
+      .each(function(index, element) {
+        fail('Button has no text:', element)
+      });
   }
 }


### PR DESCRIPTION
This change skips the  "Fields must have labels or titles" check for `<input type="submit" />` and `<input type="reset" />` and `<button />`.

@EmmaJP can you confirm this is good to merge?