### PR TITLE
Run specific standards with only_standard, fixes #93

### DIFF
--- a/GETTINGSTARTED.md
+++ b/GETTINGSTARTED.md
@@ -18,7 +18,7 @@ then:
 Create or amend your your project's `Gemfile` to include this line:
 
     gem 'bbc-a11y'
-    
+
     source 'https://rubygems.org'
 
 Now install the gem:
@@ -49,7 +49,14 @@ end
 page "http://bbc.co.uk/news"
 ```
 
-A11y will skip any standards from whose name matches that string.
+A11y will skip any standards from whose name matches that string. Or you could
+use `only_standard` when you want to focus your attention on just one problem:
+
+```
+page "http://bbc.co.uk" do
+  only_standard 'Focusable controls: Anchors must have hrefs'
+end
+```
 
 ## Running it
 

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -13,3 +13,17 @@ Feature: Skipping Standards
       """
       ✓ http://localhost:54321/missing_header.html
       """
+
+  Scenario: All standards except one is skipped
+    Given a website running at http://localhost:54321
+    And a file named "a11y.rb" with:
+      """
+      page "http://localhost:54321/two_headings_failures.html" do
+        only_standard "Headings: exactly one main heading"
+      end
+      """
+    When I run `a11y`
+    Then it should fail with:
+      """
+      1 page checked, 1 error found, 11 standards skipped
+      """

--- a/lib/bbc/a11y/configuration.rb
+++ b/lib/bbc/a11y/configuration.rb
@@ -74,21 +74,17 @@ module BBC
       class PageSettings
         attr_reader :url
         attr_reader :skipped_standards
+        attr_reader :only_standards
 
-        def initialize(url, skipped_standards=[])
+        def initialize(url, skipped_standards=[], only_standards=[])
           @url = url
           @skipped_standards = skipped_standards
+          @only_standards = only_standards
           freeze
         end
 
         def merge(other)
           self.class.new(url, skipped_standards + other.skipped_standards)
-        end
-
-        def skip_standard?(standard)
-          @skipped_standards.any? { |pattern|
-            pattern.match(standard.name)
-          }
         end
       end
 
@@ -151,6 +147,10 @@ module BBC
 
         def skip_standard(pattern)
           @settings.skipped_standards << pattern
+        end
+
+        def only_standard(pattern)
+          @settings.only_standards << pattern
         end
 
       end

--- a/lib/bbc/a11y/js/standards.js
+++ b/lib/bbc/a11y/js/standards.js
@@ -1,8 +1,9 @@
 var xpath = require('./xpath');
 
-function Standards(standards, skipped) {
+function Standards(standards, skipped, only) {
   this.standards = standards;
   this.skipped = skipped;
+  this.only = only;
 }
 
 Standards.sections = {
@@ -87,7 +88,7 @@ Standards.matching = function(criteria) {
     return Standards.matching({});
   }
   if (typeof(criteria) == 'string') {
-    return Standards.matching({ only: criteria });
+    return Standards.matching({ only: [criteria] });
   }
   var matching = standardsMatching(criteria);
   return new Standards(matching.matches, matching.skipped);
@@ -98,15 +99,17 @@ function standardsMatching(criteria) {
   for (var i = 0; i < skips.length; ++i) {
     skips[i] = normaliseStandardName(skips[i]);
   }
-  var isOnly = typeof(criteria.only) == 'string';
-  var only = isOnly ? normaliseStandardName(criteria.only) : null;
+  var onlies = criteria.only || [];
+  for (var i = 0; i < onlies.length; ++i) {
+    onlies[i] = normaliseStandardName(onlies[i]);
+  }
   var matches = [];
   var skipped = [];
   for (var i = 0; i < Standards.all.length; ++i) {
     var standard = Standards.all[i];
     var name = standard.section.toLowerCase() + normaliseStandardName(standard.name);
-    if (isOnly) {
-      if (only == name) {
+    if (onlies.length > 0) {
+      if (onlies.indexOf(name) > -1) {
         matches.push(standard);
       } else {
         skipped.push(standard.name);

--- a/lib/bbc/a11y/linter.rb
+++ b/lib/bbc/a11y/linter.rb
@@ -5,7 +5,7 @@ module BBC
       def lint(page_settings)
         browser.visit page_settings.url
         browser.execute_script(BBC::A11y::Javascript.bundle)
-        criteria = { skip: page_settings.skipped_standards }.to_json
+        criteria = { skip: page_settings.skipped_standards, only: page_settings.only_standards }.to_json
         validation = browser.evaluate_script("a11y.validate(#{criteria})")
         LintResult.from_json(validation)
       end

--- a/spec/bbc/a11y/configuration_spec.rb
+++ b/spec/bbc/a11y/configuration_spec.rb
@@ -19,31 +19,5 @@ module BBC::A11y
       expect(configuration.pages[1].url).to eq "two.html"
     end
 
-    it "allows you to specify settings for all pages matching a given URL pattern" do
-      configuration = BBC::A11y.configure do
-        page "three.html" do
-          skip_standard /^Foo/
-        end
-        page "four.html"
-        page "five.html"
-
-        for_pages_matching /^f/ do
-          skip_standard /^Bar/
-        end
-
-        for_pages_matching /^five/ do
-          skip_standard /^Baz/
-        end
-      end
-
-      bar = double(name: "BarStandard")
-      baz = double(name: "BazStandard")
-      four_page_settings = configuration.pages[1]
-      expect(four_page_settings.skip_standard?(bar)).to be_truthy
-      five_page_settings = configuration.pages[2]
-      expect(five_page_settings.skip_standard?(bar)).to be_truthy
-      expect(five_page_settings.skip_standard?(baz)).to be_truthy
-    end
-
   end
 end

--- a/spec/bbc/a11y/js/a11ySpec.js
+++ b/spec/bbc/a11y/js/a11ySpec.js
@@ -48,4 +48,10 @@ describe('a11y', function() {
     var validation = a11y.validate({ skip: ['Main landmark: Exactly one main landmark'] });
     expect(validation.skipped).to.eql(['Exactly one main landmark']);
   });
+
+  it('only runs specific standards', function() {
+    var validation = a11y.validate({ only: ['Main landmark: Exactly one main landmark'] });
+    expect(validation.results.length).to.equal(1)
+    expect(validation.results[0].standard.name).to.equal('Exactly one main landmark')
+  });
 });

--- a/spec/bbc/a11y/js/standardsSpec.js
+++ b/spec/bbc/a11y/js/standardsSpec.js
@@ -23,9 +23,9 @@ describe('standards', function() {
     });
   });
 
-  describe('.matching({ only: "Focusable controls: Anchors must have hrefs" })', function() {
+  describe('.matching({ only: ["Focusable controls: Anchors must have hrefs"] })', function() {
     it('finds one standard', function() {
-      var matches = standards.matching({ only: "Focusable controls: Anchors must have hrefs" });
+      var matches = standards.matching({ only: ["Focusable controls: Anchors must have hrefs"] });
       expect(matches.standards.length).to.equal(1);
     });
   });


### PR DESCRIPTION
When you want to run specific scenarios, use `only_standard` like  this:

```js
page "http://whatevs.com" do
  only_standard 'Focusable controls: Anchors must have hrefs'
end
```