### PR TITLE
Upgrade cucumber-electron to 2.0.1

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,3 +1,3 @@
 module.exports = {
-  default: '--require features/step_definitions/a11y_steps.js --tags ~@keep-ansi-escape-sequences'
+  default: '--tags \'not @keep-ansi-escape-sequences\''
 }

--- a/features/cli/display_failing_result.feature
+++ b/features/cli/display_failing_result.feature
@@ -2,7 +2,7 @@ Feature: Display failing result
 
   Scenario: One standard fails
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/missing_header.html`
+    When I run `bbc-a11y http://localhost:54321/missing_header.html`
     Then it should fail with:
       """
       ✗ http://localhost:54321/missing_header.html
@@ -12,7 +12,7 @@ Feature: Display failing result
 
   Scenario: Two standards fail
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/two_headings_failures.html`
+    When I run `bbc-a11y http://localhost:54321/two_headings_failures.html`
     Then it should fail with:
       """
       ✗ http://localhost:54321/two_headings_failures.html

--- a/features/cli/display_result_summary.feature
+++ b/features/cli/display_result_summary.feature
@@ -10,7 +10,7 @@ Feature: Display result summary
         skip: "Headings: exactly one main heading"
       })
       """
-    When I run `a11y`
+    When I run `bbc-a11y`
     Then it should fail with:
       """
       3 pages checked, 1 error found, 1 standard skipped
@@ -18,7 +18,7 @@ Feature: Display result summary
 
   Scenario: Reminds users to consider usability beyond lint results
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/perfect.html`
+    When I run `bbc-a11y http://localhost:54321/perfect.html`
     Then it should pass with:
       """
       No errors found. But please remember:

--- a/features/cli/exit_status.feature
+++ b/features/cli/exit_status.feature
@@ -9,5 +9,5 @@ Feature: Exit status
 
   Scenario: Failing test
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/missing_header.html`
+    When I run `bbc-a11y http://localhost:54321/missing_header.html`
     Then the exit status should be 1

--- a/features/cli/interactive_mode.feature
+++ b/features/cli/interactive_mode.feature
@@ -2,5 +2,5 @@ Feature: Interactive Mode
 
   Scenario: Running a11y interactively
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/perfect.html --interactive`
+    When I run `bbc-a11y http://localhost:54321/perfect.html --interactive`
     And the window should remain open

--- a/features/cli/missing_config_file_warning.feature
+++ b/features/cli/missing_config_file_warning.feature
@@ -1,7 +1,7 @@
 Feature: Missing configuration file warning
 
   Scenario: Running the tool with no arguments and no config file
-    When I run `a11y`
+    When I run `bbc-a11y`
     Then it should fail with:
       """
       Missing configuration file (a11y.js).

--- a/features/cli/report_configuration_errors.feature
+++ b/features/cli/report_configuration_errors.feature
@@ -9,7 +9,7 @@ Feature: Report configuration errors
       page("three")
       page("four")
       """
-    When I run `a11y`
+    When I run `bbc-a11y`
     Then it should fail with exactly:
       """
       There was an error reading your configuration file at line 3 of 'a11y.js'
@@ -25,7 +25,7 @@ Feature: Report configuration errors
         """
         throw new Error("oops")
         """
-      When I run `a11y`
+      When I run `bbc-a11y`
       Then it should fail with exactly:
         """
         There was an error reading your configuration file at line 1 of 'a11y.js'

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -8,7 +8,7 @@ Feature: Skipping Standards
         skip: "Headings: exactly one main heading"
       })
       """
-    When I run `a11y`
+    When I run `bbc-a11y`
     Then it should pass with:
       """
       ✓ http://localhost:54321/missing_header.html
@@ -22,7 +22,7 @@ Feature: Skipping Standards
         only: "Headings: exactly one main heading"
       })
       """
-    When I run `a11y`
+    When I run `bbc-a11y`
     Then it should fail with:
       """
       1 page checked, 1 error found, 11 standards skipped

--- a/features/cli/specify_url.feature
+++ b/features/cli/specify_url.feature
@@ -2,7 +2,7 @@ Feature: Specify URL
 
   Scenario: No config, just pass page URL on command-line
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/perfect.html`
+    When I run `bbc-a11y http://localhost:54321/perfect.html`
     Then it should pass with:
       """
       ✓ http://localhost:54321/perfect.html

--- a/features/cli/specify_url_via_config.feature
+++ b/features/cli/specify_url_via_config.feature
@@ -6,7 +6,7 @@ Feature: Specify URL via config
       """
       page('http://localhost:54321/perfect.html')
       """
-    When I run `a11y`
+    When I run `bbc-a11y`
     Then it should pass with:
       """
       ✓ http://localhost:54321/perfect.html

--- a/features/disabled_caching.feature
+++ b/features/disabled_caching.feature
@@ -5,7 +5,7 @@ Feature: Disabled Caching
 
   Scenario: Re-testing an updated page
     Given a website running at http://localhost:54321
-    When I run `a11y http://localhost:54321/goodThenBad.html`
+    When I run `bbc-a11y http://localhost:54321/goodThenBad.html`
     Then it should pass with:
       """
       No errors found. But please remember:
@@ -16,7 +16,7 @@ Feature: Disabled Caching
       technologies like VoiceOver, JAWS and NVDA to make sure you're providing a good
       user experience.
       """
-    When I run `a11y http://localhost:54321/goodThenBad.html`
+    When I run `bbc-a11y http://localhost:54321/goodThenBad.html`
     Then it should fail with:
       """
       ✗ http://localhost:54321/goodThenBad.html

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -15,7 +15,8 @@ function runA11y(args) {
   return new Promise(function(resolve, reject) {
     const execFile = childProcess.execFile
     const result = {}
-    var child = execFile(path.resolve(__dirname, '../../bin/bbc-a11y.js'), (args && [args]) || [], { cwd: tempDir }, (error, stdout, stderr) => {
+    const binaryPath = path.resolve(__dirname, '../../bin/bbc-a11y.js')
+    const child = execFile(binaryPath, (args && [args]) || [], { cwd: tempDir }, (error, stdout, stderr) => {
       if (error) {
         result.error = error
       }
@@ -63,7 +64,7 @@ defineSupportCode(function({ Given, When, Then, Before, After }) {
       })
   })
 
-  When(/^I run `a11y`$/, function () {
+  When(/^I run `bbc-a11y`$/, function () {
     var scenario = this
     return runA11y('')
       .then(function(result) {
@@ -73,7 +74,7 @@ defineSupportCode(function({ Given, When, Then, Before, After }) {
       })
   })
 
-  When(/^I run `a11y (http:[^\s]+)`$/, function (url) {
+  When(/^I run `bbc-a11y (http:[^\s]+)`$/, function (url) {
     var scenario = this
     return runA11y(url)
       .then(function(result) {
@@ -83,7 +84,7 @@ defineSupportCode(function({ Given, When, Then, Before, After }) {
       })
   })
 
-  When(/^I run `a11y (http:[^\s]+) --interactive`$/, function (url) {
+  When(/^I run `bbc-a11y (http:[^\s]+) --interactive`$/, function (url) {
     return runA11yInteractively(url)
       .then(interactiveProcess => {
         this.interactiveProcess = interactiveProcess

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -1,3 +1,4 @@
+const { defineSupportCode } = require('cucumber')
 var assert = require('assert')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
@@ -39,16 +40,17 @@ function runA11yInteractively(args) {
   })
 }
 
-module.exports = function() {
-  this.Given(/^a website running at http:\/\/localhost:(\d+)$/, function(port) {
+defineSupportCode(function({ Given, When, Then, Before, After }) {
+
+  Given(/^a website running at http:\/\/localhost:(\d+)$/, function(port) {
     return webServer.ensureRunningOn(Number(port))
   })
 
-  this.Given(/^a file named "([^"]*)" with:$/, function (path, contents) {
+  Given(/^a file named "([^"]*)" with:$/, function (path, contents) {
     require('fs').writeFileSync(tempDir + '/' + path, contents, 'utf-8')
   })
 
-  this.Given(/^all the tests pass$/, function () {
+  Given(/^all the tests pass$/, function () {
     var scenario = this
     return webServer.ensureRunningOn(54321)
       .then(function() {
@@ -61,7 +63,7 @@ module.exports = function() {
       })
   })
 
-  this.When(/^I run `a11y`$/, function () {
+  When(/^I run `a11y`$/, function () {
     var scenario = this
     return runA11y('')
       .then(function(result) {
@@ -71,7 +73,7 @@ module.exports = function() {
       })
   })
 
-  this.When(/^I run `a11y (http:[^\s]+)`$/, function (url) {
+  When(/^I run `a11y (http:[^\s]+)`$/, function (url) {
     var scenario = this
     return runA11y(url)
       .then(function(result) {
@@ -81,14 +83,14 @@ module.exports = function() {
       })
   })
 
-  this.When(/^I run `a11y (http:[^\s]+) --interactive`$/, function (url) {
+  When(/^I run `a11y (http:[^\s]+) --interactive`$/, function (url) {
     return runA11yInteractively(url)
       .then(interactiveProcess => {
         this.interactiveProcess = interactiveProcess
       })
   })
 
-  this.When(/^I run a11y against a failing page$/, function () {
+  When(/^I run a11y against a failing page$/, function () {
     var scenario = this
     return webServer.ensureRunningOn(54321)
       .then(function() {
@@ -101,7 +103,7 @@ module.exports = function() {
       })
   })
 
-  this.Given(/^a page with the HTML:$/, function (html) {
+  Given(/^a page with the HTML:$/, function (html) {
     this.pageFrame = document.createElement('iframe')
     document.body.appendChild(this.pageFrame)
     return new Promise((resolve, reject) => {
@@ -112,7 +114,7 @@ module.exports = function() {
     })
   })
 
-  this.Given(/^a page with the body:$/, function (body) {
+  Given(/^a page with the body:$/, function (body) {
     this.pageFrame = document.createElement('iframe')
     document.body.appendChild(this.pageFrame)
     return new Promise((resolve, reject) => {
@@ -123,37 +125,37 @@ module.exports = function() {
     })
   })
 
-  this.When(/^I validate the "([^"]*)" standard$/, function (name) {
+  When(/^I validate the "([^"]*)" standard$/, function (name) {
     var $ = jquery(this.pageFrame.contentDocument)
     var standards = Standards.matching(name)
     this.validationResult = standards.validate($.find.bind($))
   })
 
-  this.Then(/^it passes$/, function () {
+  Then(/^it passes$/, function () {
     var pass = !this.validationResult.results.find(function(result) {
       return result.errors.length > 0
     })
     assert(pass)
   })
 
-  this.Then(/^it should fail with:$/, function (string) {
+  Then(/^it should fail with:$/, function (string) {
     var output = this.stdout + this.stderr
     assert(output.indexOf(string) > -1, "Expected:\n" + string + "\nActual:\n" + output)
   })
 
-  this.Then(/^it should fail with exactly:$/, function (expectedOutput) {
+  Then(/^it should fail with exactly:$/, function (expectedOutput) {
     var actualOutput = (this.stdout + this.stderr)
     // HACK: work around stupid travis issue with xvfb
     var sanitisedActualOutput = actualOutput.split("\n").filter(line => line != 'Xlib:  extension "RANDR" missing on display ":99.0".').join("\n")
     assert.equal(sanitisedActualOutput, expectedOutput, "Expected:\n" + expectedOutput.replace(/\n/g, "[\\n]\n") + "\nActual:\n" + sanitisedActualOutput.replace(/\n/g, "[\\n]\n"))
   })
 
-  this.Then(/^it should pass with:$/, function (string) {
+  Then(/^it should pass with:$/, function (string) {
     var output = this.stdout
     assert(output.indexOf(string) > -1, "Expected: " + string + "\nActual:   " + output)
   })
 
-  this.Then(/^it fails with the message:$/, function (message) {
+  Then(/^it fails with the message:$/, function (message) {
     var actualMessage = this.validationResult.results.filter(function(result) {
       return result.errors.length > 0
     }).map(function(err) {
@@ -166,11 +168,11 @@ module.exports = function() {
     assert.equal(message, actualMessage)
   })
 
-  this.Then(/^the exit status should be (\d+)$/, function (status) {
+  Then(/^the exit status should be (\d+)$/, function (status) {
     assert.equal(this.exitCode, status)
   })
 
-  this.When(/^the window should remain open$/, function () {
+  When(/^the window should remain open$/, function () {
     return new Promise((resolve, reject) => {
       this.interactiveProcess.on('error', e => reject(e))
       this.interactiveProcess.on('close', (code, signal) => {
@@ -185,13 +187,14 @@ module.exports = function() {
     })
   })
 
-  this.Before(function(scenario, callback) {
+  Before(function(scenario, callback) {
     childProcess.exec('rm -rf ' + tempDir, function(err, out) {
       mkdirp(tempDir, callback)
     });
   })
 
-  this.After(function(scenario) {
+  After(function(scenario) {
     if (!scenario.isFailed() && this.pageFrame) this.pageFrame.style.display = 'none'
   })
-}
+
+})

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "browserify": "13.3.0",
     "chai": "3.5.0",
-    "cucumber-electron": "1.2.5",
+    "cucumber-electron": "2.0.1",
     "diff": "3.2.0",
     "electron-mocha": "3.3.0",
     "express": "4.14.0",


### PR DESCRIPTION
Upgrading cucumber-electron to 2.0.1 means we keep up to date with cucumber-js and get to use new features like cucumber expressions instead of regexes in step definitions.