### PR TITLE
Fix content follows headings false negatives

### DIFF
--- a/features/check_standards/07_headings.feature
+++ b/features/check_standards/07_headings.feature
@@ -210,6 +210,28 @@ Feature: Headings
     When I validate the "Headings: content must follow headings" standard
     Then it passes
 
+  Scenario: Nested heading surrounded by no whitespace followed by content
+    Given a page with the body:
+      """
+      <div>
+        <div><h1>News headlines</h1></div>
+        Content
+      </div>
+      """
+    When I validate the "Headings: content must follow headings" standard
+    Then it passes
+
+  Scenario: Doubly-nested heading surrounded by no whitespace followed by content
+    Given a page with the body:
+      """
+      <div>
+        <div><div><h1>News headlines</h1></div></div>
+        Content
+      </div>
+      """
+    When I validate the "Headings: content must follow headings" standard
+    Then it passes
+
   Scenario: Non-nested heading followed by nested content
     Given a page with the body:
       """

--- a/features/support/timeouts.js
+++ b/features/support/timeouts.js
@@ -1,0 +1,5 @@
+var {defineSupportCode} = require('cucumber');
+
+defineSupportCode(function({setDefaultTimeout}) {
+  setDefaultTimeout(10000)
+});

--- a/lib/standards/headings/contentMustFollowHeadings.js
+++ b/lib/standards/headings/contentMustFollowHeadings.js
@@ -1,18 +1,25 @@
-var headingSelector = 'h1, h2, h3, h4, h5, h6, h7, h8';
+var headingSelector = 'h1, h2, h3, h4, h5, h6, h7, h8'
 
 module.exports = {
   name: 'Content must follow headings',
 
   validate: function($, fail) {
+
+    function ancestorsNextSibling(element) {
+      return $(element).parents().filter(
+        function() { return this.nextSibling }
+      ).map(function() { return this.nextSibling } )[0]
+    }
+
     $(headingSelector).each(function(index, heading) {
-      var nextSibling = heading.nextSibling;
-      while (nextSibling) {
-        if ($(nextSibling).is(heading.tagName)) { break; }
-        if ($(nextSibling).text().trim().length > 0) { return; }
-        nextSibling = nextSibling.nextSibling ?
-                      nextSibling.nextSibling : (nextSibling.parentNode && nextSibling.parentNode.nextSibling);
+      var nextNode = heading.nextSibling || ancestorsNextSibling(heading)
+      while (nextNode) {
+        if ($(nextNode).is(heading.tagName)) { break }
+        if ($(nextNode).text().trim().length > 0) { return }
+        nextNode = nextNode.nextSibling ?
+                   nextNode.nextSibling : (nextNode.parentNode && nextNode.parentNode.nextSibling)
       }
-      fail("No content follows:", heading);
-    });
+      fail("No content follows:", heading)
+    })
   }
 }


### PR DESCRIPTION
Elements with no whitespace between them was causing false negatives for the "content must follow headings"