### PR TITLE
Rename missing_header to missing_main_heading

### DIFF
--- a/features/cli/display_failing_result.feature
+++ b/features/cli/display_failing_result.feature
@@ -2,10 +2,10 @@ Feature: Display failing result
 
   Scenario: One standard fails
     Given a website running at http://localhost:54321
-    When I run `bbc-a11y http://localhost:54321/missing_header.html`
+    When I run `bbc-a11y http://localhost:54321/missing_main_heading.html`
     Then it should fail with:
       """
-      ✗ http://localhost:54321/missing_header.html
+      ✗ http://localhost:54321/missing_main_heading.html
         * Headings: Exactly one main heading
           - Found 0 h1 elements.
       """

--- a/features/cli/display_result_summary.feature
+++ b/features/cli/display_result_summary.feature
@@ -5,8 +5,8 @@ Feature: Display result summary
     And a file named "a11y.js" with:
       """
       page("http://localhost:54321/perfect.html")
-      page("http://localhost:54321/missing_header.html")
-      page("http://localhost:54321/missing_header.html?again!", {
+      page("http://localhost:54321/missing_main_heading.html")
+      page("http://localhost:54321/missing_main_heading.html?again!", {
         skip: "Headings: exactly one main heading"
       })
       """

--- a/features/cli/exit_status.feature
+++ b/features/cli/exit_status.feature
@@ -9,5 +9,5 @@ Feature: Exit status
 
   Scenario: Failing test
     Given a website running at http://localhost:54321
-    When I run `bbc-a11y http://localhost:54321/missing_header.html`
+    When I run `bbc-a11y http://localhost:54321/missing_main_heading.html`
     Then the exit status should be 1

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -4,14 +4,14 @@ Feature: Skipping Standards
     Given a website running at http://localhost:54321
     And a file named "a11y.js" with:
       """
-      page("http://localhost:54321/missing_header.html", {
+      page("http://localhost:54321/missing_main_heading.html", {
         skip: "Headings: exactly one main heading"
       })
       """
     When I run `bbc-a11y`
     Then it should pass with:
       """
-      ✓ http://localhost:54321/missing_header.html
+      ✓ http://localhost:54321/missing_main_heading.html
       """
 
   Scenario: All standards except one is skipped

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -95,7 +95,7 @@ defineSupportCode(function({ Given, When, Then, Before, After }) {
     var scenario = this
     return webServer.ensureRunningOn(54321)
       .then(function() {
-        return runA11y('http://localhost:54321/missing_header.html')
+        return runA11y('http://localhost:54321/missing_main_heading.html')
       })
       .then(function(result) {
         scenario.stdout = result.stdout

--- a/features/support/web_server.js
+++ b/features/support/web_server.js
@@ -9,7 +9,7 @@ module.exports = {
     var app = express()
     let good = true
     app.get('/goodThenBad.html', (req, res) => {
-      const page = good ? 'perfect.html' : 'missing_header.html'
+      const page = good ? 'perfect.html' : 'missing_main_heading.html'
       good = !good
       res.set('Cache-Control', 'max-age=86400').status(200).end(fs.readFileSync(__dirname + '/web_server/' + page))
     })

--- a/features/support/web_server/iframe.html
+++ b/features/support/web_server/iframe.html
@@ -5,6 +5,6 @@
 
   <body>
     <h2>Here's a frame with a missing heading:</h2>
-    <iframe src="missing_header.html"></iframe>
+    <iframe src="missing_main_heading.html"></iframe>
   </body>
 </html>

--- a/features/support/web_server/missing_main_heading.html
+++ b/features/support/web_server/missing_main_heading.html
@@ -1,6 +1,6 @@
 <html lang="en-gb">
   <head>
-    <title>Missing header</title>
+    <title>Missing main heading</title>
   </head>
 
   <body>

--- a/features/testing_iframes.feature
+++ b/features/testing_iframes.feature
@@ -5,7 +5,7 @@ Feature: Testing iframes
     And a page with the body:
       """
       <h1>This frame has no main heading:</h1>
-      <iframe src="http://localhost:54321/missing_header.html"></iframe>
+      <iframe src="http://localhost:54321/missing_main_heading.html"></iframe>
       """
     When I validate the "Headings: exactly one main heading" standard
     Then it fails with the message:


### PR DESCRIPTION
Various scenarios use an example called "missing_header" which is really missing a main _heading_ not a header