### PR TITLE
Add mocha back to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ addons:
   apt:
     packages:
       - xvfb
-      - gtk2-engines-pixbuf
-      - xfonts-cyrillic
-      - xfonts-100dpi
-      - xfonts-75dpi
-      - xfonts-base
-      - xfonts-scalable
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js:
   - "7"
 
-dist: trusty
-
 addons:
   apt:
     packages:
@@ -25,4 +23,4 @@ before_script:
   - sleep 3
 
 script:
-  - ./cucumber
+  - npm test

--- a/test/a11ySpec.js
+++ b/test/a11ySpec.js
@@ -27,7 +27,8 @@ describe('a11y', function() {
         },
         "errors":[
           ["Found 0 h1 elements."]
-        ]
+        ],
+        "hiddenErrors": []
       },
       {
         "standard": {
@@ -36,7 +37,8 @@ describe('a11y', function() {
         },
         "errors":[
           ["html tag has no lang attribute:","/html"]
-        ]
+        ],
+        "hiddenErrors": []
       },
       {
         "standard": {
@@ -45,7 +47,8 @@ describe('a11y', function() {
         },
         "errors":[
           ['Found 0 elements with role="main".']
-        ]
+        ],
+        "hiddenErrors": []
       }
     ]
     expect(JSON.stringify(errors)).to.equal(JSON.stringify(expectedErrors))
@@ -54,6 +57,15 @@ describe('a11y', function() {
   it('skips standards', function() {
     var validation = a11y.validate({ skip: ['Main landmark: Exactly one main landmark'] })
     expect(validation.skipped).to.eql(['Exactly one main landmark'])
+  })
+
+  it('hides errors', function() {
+    var validation = a11y.validate({ hide: ['Found 0 elements with role="main".'] })
+    var resultsWithErrors = validation.results.filter(function(standardResult) {
+      return standardResult.hiddenErrors.length > 0
+    })
+    expect(resultsWithErrors[0].errors).to.eql([])
+    expect(resultsWithErrors[0].hiddenErrors).to.eql([['Found 0 elements with role="main".']])
   })
 
   it('only runs specific standards', function() {

--- a/test/iframeSpec.js
+++ b/test/iframeSpec.js
@@ -33,7 +33,8 @@ describe('a11y validating in frames', function() {
         ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Found 0 h1 elements.'],
         ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: "/html/body/iframe[1]" }, ':', 'Found 0 h1 elements.'],
         ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: "/html/body/iframe[2]" }, ':', 'Found 0 h1 elements.']
-      ]
+      ],
+      hiddenErrors: []
     }])
   })
 })


### PR DESCRIPTION
I removed mocha from travis and forgot to put it back. A couple of tests broke. This fixes them, runs mocha in travis again and simplifies the travis config so the build is faster.