### PR TITLE
Title attributes must not duplicate content

### DIFF
--- a/features/check_standards/11_title_attributes.feature
+++ b/features/check_standards/11_title_attributes.feature
@@ -63,3 +63,29 @@ Feature: Title Attributes
       """
     When I validate the "Title attributes: title attributes only on inputs" standard
     Then it passes
+
+  Scenario: Title attribute duplicates content
+    Given a page with the body:
+      """
+      <a href="back" title="Back to Home">
+        <img src="back.png" /> Back to Home
+      </a>
+      """
+    When I validate the "Title attributes: title attributes must not duplicate content" standard
+    Then it fails with the message:
+      """
+      Title attribute duplicates content: /html/body/a
+      """
+
+  Scenario: Title attribute duplicates nested content
+    Given a page with the body:
+      """
+      <a href="back" title="Back to Home">
+        <span>Back to <b>Home</b></span>
+      </a>
+      """
+    When I validate the "Title attributes: title attributes must not duplicate content" standard
+    Then it fails with the message:
+      """
+      Title attribute duplicates content: /html/body/a
+      """

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -25,5 +25,5 @@ Feature: Skipping Standards
     When I run `bbc-a11y`
     Then it should fail with:
       """
-      1 page checked, 1 error found, 11 standards skipped
+      1 page checked, 1 error found, 12 standards skipped
       """

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -47,6 +47,7 @@ Standards.sections = {
   ],
 
   titleAttributes: [
+    require('./titleAttributes/titleAttributesMustNotDuplicateContent'),
     require('./titleAttributes/titleAttributesOnlyOnInputs')
   ]
 

--- a/lib/standards/titleAttributes/titleAttributesMustNotDuplicateContent.js
+++ b/lib/standards/titleAttributes/titleAttributesMustNotDuplicateContent.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: 'Title attributes must not duplicate content',
+
+  validate: function($, fail) {
+    $("[title]:visible").each(function(index, element) {
+      if ($(element).text().trim() == $(element).attr('title').trim()) {
+        fail("Title attribute duplicates content:", element)
+      }
+    });
+  }
+}


### PR DESCRIPTION
Adds a new standard check, covering title attributes that have the same text as the element itself.