### PR TITLE
Fix bug with restoring default viewport width

### DIFF
--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -16,10 +16,12 @@ const exit = commandLineArgs.interactive ?
   () => {} : electron.remote.process.exit
 
 function loadPage(page) {
-  if (page.width) {
-    const win = electron.remote.getCurrentWindow()
-    const currentHeight = win.getContentSize()[1]
-    win.setContentSize(page.width, currentHeight, false)
+  const win = electron.remote.getCurrentWindow()
+  const [currentWidth, currentHeight] = win.getContentSize()
+  const newWidth = page.width || 1024
+  const isResized = currentWidth != newWidth
+  if (isResized) {
+    win.setContentSize(newWidth, currentHeight, false)
   }
 
   return new Promise(function(resolve, reject) {
@@ -32,7 +34,9 @@ function loadPage(page) {
       resolve(jquery(mainFrame).contents())
     }
 
-    mainFrame.src = page.url
+    setTimeout(function() {
+      mainFrame.src = page.url
+    }, isResized ? 100 : 0)
   })
 }
 

--- a/features/cli/viewport_widths.feature
+++ b/features/cli/viewport_widths.feature
@@ -29,3 +29,19 @@ Feature: Viewport Widths
       """
       ✓ http://localhost:54321/perfect_when_666_wide.html --width=666
       """
+
+  Scenario: Viewport is restored to default width when is specified then not specified
+    Given a website running at http://localhost:54321
+    And a file named "a11y.js" with:
+      """
+      page("http://localhost:54321/perfect_when_666_wide.html", {
+        width: 666
+      })
+      page("http://localhost:54321/perfect_when_666_wide.html")
+      """
+    When I run `bbc-a11y`
+    Then it should fail with:
+      """
+      ✓ http://localhost:54321/perfect_when_666_wide.html --width=666
+      ✗ http://localhost:54321/perfect_when_666_wide.html
+      """

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -123,6 +123,8 @@ page("http://bbc.co.uk", {
 })
 ```
 
+If you don't specify a width, the viewport will be 1024px wide.
+
 To test the same URL with multiple widths, you can loop over the widths in your
 configuration file, for example:
 


### PR DESCRIPTION
Although it was possible to resize the viewport width on a page-by-page basis, we weren't restoring it to its default when a subsequent page had not specified a width. Also, changing the viewport width is not completely immediate either (although the electron API implies it is) so I've added a 100ms delay before validating against any new viewport width.

Finally, this also documents the default width.