### PR TITLE
Refactor sections

### DIFF
--- a/features/check_standards/01_core_purpose.feature
+++ b/features/check_standards/01_core_purpose.feature
@@ -19,7 +19,7 @@ Feature: Core Purpose
 
     * Progressive enhancement
 
-    * Minimum Text Size
+    * Minimum text size
 
   It is not a reason to ignore accessibility for non-core page elements.
 

--- a/features/check_standards/01_core_purpose.feature
+++ b/features/check_standards/01_core_purpose.feature
@@ -19,7 +19,7 @@ Feature: Core Purpose
 
     * Progressive enhancement
 
-    * Minimum text size
+    * Minimum Text Size
 
   It is not a reason to ignore accessibility for non-core page elements.
 

--- a/features/check_standards/04_indicating_language.feature
+++ b/features/check_standards/04_indicating_language.feature
@@ -23,7 +23,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the "Indicating language: html must have lang attribute" standard
+    When I validate the "Indicating Language: Html must have lang attribute" standard
     Then it passes
 
   Scenario: Missing lang attribute on html element
@@ -39,7 +39,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the "Indicating language: html must have lang attribute" standard
+    When I validate the "Indicating Language: Html must have lang attribute" standard
     Then it fails with the message:
       """
       html tag has no lang attribute: /html

--- a/features/check_standards/04_indicating_language.feature
+++ b/features/check_standards/04_indicating_language.feature
@@ -23,7 +23,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the "Indicating Language: Html must have lang attribute" standard
+    When I validate the "Indicating language: Html must have lang attribute" standard
     Then it passes
 
   Scenario: Missing lang attribute on html element
@@ -39,7 +39,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the "Indicating Language: Html must have lang attribute" standard
+    When I validate the "Indicating language: Html must have lang attribute" standard
     Then it fails with the message:
       """
       html tag has no lang attribute: /html

--- a/features/check_standards/06_main_landmark.feature
+++ b/features/check_standards/06_main_landmark.feature
@@ -15,7 +15,7 @@ Feature: Main landmark
       """
       <div role="main">Main element</div>
       """
-    When I validate the "Main landmark: exactly one main landmark" standard
+    When I validate the "Main Landmark: Exactly one main landmark" standard
     Then it passes
 
   Scenario: Page has two main elements
@@ -24,7 +24,7 @@ Feature: Main landmark
       <div role="main">Main one</div>
       <div role="main">Main two</div>
       """
-    When I validate the "Main landmark: exactly one main landmark" standard
+    When I validate the "Main Landmark: Exactly one main landmark" standard
     Then it fails with the message:
       """
       Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
@@ -35,7 +35,7 @@ Feature: Main landmark
       """
       <div role="not-main">Main one</div>
       """
-    When I validate the "Main landmark: exactly one main landmark" standard
+    When I validate the "Main Landmark: Exactly one main landmark" standard
     Then it fails with the message:
       """
       Found 0 elements with role="main".

--- a/features/check_standards/06_main_landmark.feature
+++ b/features/check_standards/06_main_landmark.feature
@@ -15,7 +15,7 @@ Feature: Main landmark
       """
       <div role="main">Main element</div>
       """
-    When I validate the "Main Landmark: Exactly one main landmark" standard
+    When I validate the "Main landmark: Exactly one Main landmark" standard
     Then it passes
 
   Scenario: Page has two main elements
@@ -24,7 +24,7 @@ Feature: Main landmark
       <div role="main">Main one</div>
       <div role="main">Main two</div>
       """
-    When I validate the "Main Landmark: Exactly one main landmark" standard
+    When I validate the "Main landmark: Exactly one Main landmark" standard
     Then it fails with the message:
       """
       Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
@@ -35,7 +35,7 @@ Feature: Main landmark
       """
       <div role="not-main">Main one</div>
       """
-    When I validate the "Main Landmark: Exactly one main landmark" standard
+    When I validate the "Main landmark: Exactly one Main landmark" standard
     Then it fails with the message:
       """
       Found 0 elements with role="main".

--- a/features/check_standards/07_headings.feature
+++ b/features/check_standards/07_headings.feature
@@ -28,7 +28,7 @@ Feature: Headings
       """
       <h2>Heading 2</h2>
       """
-    When I validate the "Headings: exactly one main heading" standard
+    When I validate the "Headings: Exactly one main heading" standard
     Then it fails with the message:
       """
       Found 0 h1 elements.
@@ -41,7 +41,7 @@ Feature: Headings
       <h2>Heading 2</h2>
       <h1>Heading 1</h1>
       """
-    When I validate the "Headings: exactly one main heading" standard
+    When I validate the "Headings: Exactly one main heading" standard
     Then it fails with the message:
       """
       Found 2 h1 elements: /html/body/h1[1] /html/body/h1[2]
@@ -53,7 +53,7 @@ Feature: Headings
       <h1>A Heading</h1>
       <h1 style="display:none">Another Heading</h1>
       """
-    When I validate the "Headings: exactly one main heading" standard
+    When I validate the "Headings: Exactly one main heading" standard
     Then it passes
 
   Scenario: Headings in ascending order
@@ -66,7 +66,7 @@ Feature: Headings
       <h5>Heading 5</h5>
       <h6>Heading 6</h6>
       """
-    When I validate the "Headings: headings must be in ascending order" standard
+    When I validate the "Headings: Headings must be in ascending order" standard
     Then it passes
 
   Scenario: Headings in invalid order
@@ -76,7 +76,7 @@ Feature: Headings
       <h3>Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the "Headings: headings must be in ascending order" standard
+    When I validate the "Headings: Headings must be in ascending order" standard
     Then it fails with the message:
       """
       Headings are not in order: /html/body/h1 /html/body/h3
@@ -92,7 +92,7 @@ Feature: Headings
       <h2>Heading 2b</h2>
       <h3>Heading 3b</h3>
       """
-    When I validate the "Headings: headings must be in ascending order" standard
+    When I validate the "Headings: Headings must be in ascending order" standard
     Then it passes
 
   Scenario: Heading is hidden
@@ -102,7 +102,7 @@ Feature: Headings
       <h3 style="display:none">Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the "Headings: headings must be in ascending order" standard
+    When I validate the "Headings: Headings must be in ascending order" standard
     Then it fails with the message:
       """
       Headings are not in order: /html/body/h1 /html/body/h3
@@ -117,7 +117,7 @@ Feature: Headings
       </script>
       <h2>Heading 2</h2>
       """
-    When I validate the "Headings: headings must be in ascending order" standard
+    When I validate the "Headings: Headings must be in ascending order" standard
     Then it passes
 
   Scenario: Subheading before the first main heading
@@ -127,7 +127,7 @@ Feature: Headings
       <h1>Heading 1</h1>
       <h2>Heading 2</h2>
       """
-    When I validate the "Headings: headings must be in ascending order" standard
+    When I validate the "Headings: Headings must be in ascending order" standard
     Then it passes
 
   Scenario: Content between headings
@@ -146,7 +146,7 @@ Feature: Headings
         non-heading content
       </div>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes
 
   Scenario: Heading followed by subheading
@@ -156,7 +156,7 @@ Feature: Headings
       <h2>Another heading</h2>
       <p>...and some content</p>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes
 
   Scenario: No content between headings
@@ -170,7 +170,7 @@ Feature: Headings
         <p>non-heading content</p>
       </div>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it fails with the message:
       """
       No content follows: /html/body/div/h2[1]
@@ -186,7 +186,7 @@ Feature: Headings
       <h2>Another subheading</h2>
       Content
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it fails with the message:
       """
       No content follows: /html/body/div/h2
@@ -200,7 +200,7 @@ Feature: Headings
       </div>
       Followed by some content
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes
 
   Scenario: Nested heading followed by nested content
@@ -213,7 +213,7 @@ Feature: Headings
         Followed by some content
       </div>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes
 
   Scenario: Nested heading surrounded by no whitespace followed by content
@@ -224,7 +224,7 @@ Feature: Headings
         Content
       </div>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes
 
   Scenario: Doubly-nested heading surrounded by no whitespace followed by content
@@ -235,7 +235,7 @@ Feature: Headings
         Content
       </div>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes
 
   Scenario: Non-nested heading followed by nested content
@@ -246,5 +246,5 @@ Feature: Headings
         Followed by some content
       </div>
       """
-    When I validate the "Headings: content must follow headings" standard
+    When I validate the "Headings: Content must follow headings" standard
     Then it passes

--- a/features/check_standards/08_minimum_text_size.feature
+++ b/features/check_standards/08_minimum_text_size.feature
@@ -1,4 +1,4 @@
-Feature: Minimum Text Size
+Feature: Minimum text size
 
   At default browser level all text **must** have a minimum calculated size of
   11px and all core content **must** have a minimum calculated size of 13px.
@@ -6,7 +6,7 @@ Feature: Minimum Text Size
   Rationale
   =========
 
-  Having a Minimum Text Size will reduce the number of users who need to make
+  Having a Minimum text size will reduce the number of users who need to make
   use of browser based text resize or page zoom. This is a particular issue with
   an ageing audience, many of whom will not consider themselves as having low
   vision and there will not have access to assistive technology or be familiar
@@ -26,7 +26,7 @@ Feature: Minimum Text Size
       </style>
       <span>Some text</span> with <span>more <b>text</b> also</span>.
       """
-    When I validate the "Minimum Text Size: Text cannot be too small" standard
+    When I validate the "Minimum text size: Text cannot be too small" standard
     Then it fails with the message:
       """
       Text size too small (10px): /html/body
@@ -43,7 +43,7 @@ Feature: Minimum Text Size
         </style>
         <span style="font-size: 1px">Tiny text, but it's hidden!</span>
         """
-      When I validate the "Minimum Text Size: Text cannot be too small" standard
+      When I validate the "Minimum text size: Text cannot be too small" standard
       Then it passes
 
     Scenario: Text nodes with only whitespace
@@ -52,5 +52,5 @@ Feature: Minimum Text Size
         <div id="blq-global" style="font-size: 1px"> <div id="blq-pre-mast">  </div> &nbsp;
         </div>
         """
-      When I validate the "Minimum Text Size: Text cannot be too small" standard
+      When I validate the "Minimum text size: Text cannot be too small" standard
       Then it passes

--- a/features/check_standards/08_minimum_text_size.feature
+++ b/features/check_standards/08_minimum_text_size.feature
@@ -1,4 +1,4 @@
-Feature: Minimum text size
+Feature: Minimum Text Size
 
   At default browser level all text **must** have a minimum calculated size of
   11px and all core content **must** have a minimum calculated size of 13px.
@@ -6,7 +6,7 @@ Feature: Minimum text size
   Rationale
   =========
 
-  Having a minimum text size will reduce the number of users who need to make
+  Having a Minimum Text Size will reduce the number of users who need to make
   use of browser based text resize or page zoom. This is a particular issue with
   an ageing audience, many of whom will not consider themselves as having low
   vision and there will not have access to assistive technology or be familiar
@@ -26,7 +26,7 @@ Feature: Minimum text size
       </style>
       <span>Some text</span> with <span>more <b>text</b> also</span>.
       """
-    When I validate the "Minimum text size: text cannot be too small" standard
+    When I validate the "Minimum Text Size: Text cannot be too small" standard
     Then it fails with the message:
       """
       Text size too small (10px): /html/body
@@ -43,7 +43,7 @@ Feature: Minimum text size
         </style>
         <span style="font-size: 1px">Tiny text, but it's hidden!</span>
         """
-      When I validate the "Minimum text size: text cannot be too small" standard
+      When I validate the "Minimum Text Size: Text cannot be too small" standard
       Then it passes
 
     Scenario: Text nodes with only whitespace
@@ -52,5 +52,5 @@ Feature: Minimum text size
         <div id="blq-global" style="font-size: 1px"> <div id="blq-pre-mast">  </div> &nbsp;
         </div>
         """
-      When I validate the "Minimum text size: text cannot be too small" standard
+      When I validate the "Minimum Text Size: Text cannot be too small" standard
       Then it passes

--- a/features/check_standards/10_tab_index.feature
+++ b/features/check_standards/10_tab_index.feature
@@ -1,4 +1,4 @@
-Feature: Tab Index
+Feature: Tab index
 
   Positive `tabindex` attribute values **must not** be used to create a logical
   tab order.
@@ -21,17 +21,17 @@ Feature: Tab Index
   element. There are no circumstances in which it is not better to use a
   natively focusable control such as a `<a>` or `<button>`.
 
-  Scenario: Element with negative tab index
+  Scenario: Element with negative Tab index
     Given a page with the body:
       """
       <a href="/news">News</a>
       <button type="submit">Search</button>
       <div tabindex="-1"></div>
       """
-    When I validate the "Tab Index: Zero tab index must only be set on elements which are focusable by default" standard
+    When I validate the "Tab index: Zero Tab index must only be set on elements which are focusable by default" standard
     Then it passes
 
-  Scenario: Focusable elements with zero tab index
+  Scenario: Focusable elements with zero Tab index
     Given a page with the body:
       """
       <a href="/news" tabindex="0">News</a>
@@ -40,10 +40,10 @@ Feature: Tab Index
       <select tabindex="0"></select>
       <textarea tabindex="0"></textarea>
       """
-    When I validate the "Tab Index: Zero tab index must only be set on elements which are focusable by default" standard
+    When I validate the "Tab index: Zero Tab index must only be set on elements which are focusable by default" standard
     Then it passes
 
-  Scenario: Unfocusable element with zero tab index
+  Scenario: Unfocusable element with zero Tab index
     Given a page with the body:
       """
       <a href="/news" tabindex="1">News</a>
@@ -51,7 +51,7 @@ Feature: Tab Index
       <div tabindex="3"></div>
       <div tabindex="0"></div>
       """
-    When I validate the "Tab Index: Zero tab index must only be set on elements which are focusable by default" standard
+    When I validate the "Tab index: Zero Tab index must only be set on elements which are focusable by default" standard
     Then it fails with the message:
       """
       Non-focusable element with tabindex=0: /html/body/div[2]

--- a/features/check_standards/11_title_attributes.feature
+++ b/features/check_standards/11_title_attributes.feature
@@ -32,7 +32,7 @@ Feature: Title Attributes
         <img src="close.png" />
       </button>
       """
-    When I validate the "Title attributes: title attributes only on inputs" standard
+    When I validate the "Title Attributes: Title attributes only on inputs" standard
     Then it passes
 
   Scenario: Hidden element with title attribute
@@ -40,7 +40,7 @@ Feature: Title Attributes
       """
       <iframe style="display:none" title="Ignore me, I'm invisible"></iframe>
       """
-    When I validate the "Title attributes: title attributes only on inputs" standard
+    When I validate the "Title Attributes: Title attributes only on inputs" standard
     Then it passes
 
   Scenario: Anchor tag with title attribute
@@ -50,7 +50,7 @@ Feature: Title Attributes
         <img src="close.png" />
       </a>
       """
-    When I validate the "Title attributes: title attributes only on inputs" standard
+    When I validate the "Title Attributes: Title attributes only on inputs" standard
     Then it fails with the message:
       """
       Non-input element has title attribute: /html/body/a
@@ -61,7 +61,7 @@ Feature: Title Attributes
       """
       <iframe src="perfect.html" title="Rainbows and unicorns"></iframe>
       """
-    When I validate the "Title attributes: title attributes only on inputs" standard
+    When I validate the "Title Attributes: Title attributes only on inputs" standard
     Then it passes
 
   Scenario: Title attribute duplicates content
@@ -71,7 +71,7 @@ Feature: Title Attributes
         <img src="back.png" /> Back to Home
       </a>
       """
-    When I validate the "Title attributes: title attributes must not duplicate content" standard
+    When I validate the "Title Attributes: Title attributes must not duplicate content" standard
     Then it fails with the message:
       """
       Title attribute duplicates content: /html/body/a
@@ -84,7 +84,7 @@ Feature: Title Attributes
         <span>Back to <b>Home</b></span>
       </a>
       """
-    When I validate the "Title attributes: title attributes must not duplicate content" standard
+    When I validate the "Title Attributes: Title attributes must not duplicate content" standard
     Then it fails with the message:
       """
       Title attribute duplicates content: /html/body/a

--- a/features/check_standards/11_title_attributes.feature
+++ b/features/check_standards/11_title_attributes.feature
@@ -1,4 +1,4 @@
-Feature: Title Attributes
+Feature: Title attributes
 
   `title` attributes **must not** be used for critical information and **must
   not** repeat content that is already visible and associated with the same
@@ -32,7 +32,7 @@ Feature: Title Attributes
         <img src="close.png" />
       </button>
       """
-    When I validate the "Title Attributes: Title attributes only on inputs" standard
+    When I validate the "Title attributes: Title attributes only on inputs" standard
     Then it passes
 
   Scenario: Hidden element with title attribute
@@ -40,7 +40,7 @@ Feature: Title Attributes
       """
       <iframe style="display:none" title="Ignore me, I'm invisible"></iframe>
       """
-    When I validate the "Title Attributes: Title attributes only on inputs" standard
+    When I validate the "Title attributes: Title attributes only on inputs" standard
     Then it passes
 
   Scenario: Anchor tag with title attribute
@@ -50,7 +50,7 @@ Feature: Title Attributes
         <img src="close.png" />
       </a>
       """
-    When I validate the "Title Attributes: Title attributes only on inputs" standard
+    When I validate the "Title attributes: Title attributes only on inputs" standard
     Then it fails with the message:
       """
       Non-input element has title attribute: /html/body/a
@@ -61,7 +61,7 @@ Feature: Title Attributes
       """
       <iframe src="perfect.html" title="Rainbows and unicorns"></iframe>
       """
-    When I validate the "Title Attributes: Title attributes only on inputs" standard
+    When I validate the "Title attributes: Title attributes only on inputs" standard
     Then it passes
 
   Scenario: Title attribute duplicates content
@@ -71,7 +71,7 @@ Feature: Title Attributes
         <img src="back.png" /> Back to Home
       </a>
       """
-    When I validate the "Title Attributes: Title attributes must not duplicate content" standard
+    When I validate the "Title attributes: Title attributes must not duplicate content" standard
     Then it fails with the message:
       """
       Title attribute duplicates content: /html/body/a
@@ -84,7 +84,7 @@ Feature: Title Attributes
         <span>Back to <b>Home</b></span>
       </a>
       """
-    When I validate the "Title Attributes: Title attributes must not duplicate content" standard
+    When I validate the "Title attributes: Title attributes must not duplicate content" standard
     Then it fails with the message:
       """
       Title attribute duplicates content: /html/body/a

--- a/features/check_standards/12_focusable_controls.feature
+++ b/features/check_standards/12_focusable_controls.feature
@@ -1,4 +1,4 @@
-Feature: Focusable Controls
+Feature: Focusable controls
 
   Controls for JavaScript enhanced interactions **must** be `<a>`, `<button>`,
   or `<input>` elements if that is the only mechanism for controlling them.
@@ -42,7 +42,7 @@ Feature: Focusable Controls
           <li><a href="#entertainmenttab">Entertainment</a></li>
       </ul>
       """
-    When I validate the "Focusable Controls: Anchors must have hrefs" standard
+    When I validate the "Focusable controls: Anchors must have hrefs" standard
     Then it passes
 
   Scenario: Some anchor tags do not have href attributes
@@ -54,7 +54,7 @@ Feature: Focusable Controls
           <li><a>Entertainment</a></li>
       </ul>
       """
-    When I validate the "Focusable Controls: Anchors must have hrefs" standard
+    When I validate the "Focusable controls: Anchors must have hrefs" standard
     Then it fails with the message:
       """
       Anchor has no href attribute: /html/body/ul/li[1]/a

--- a/features/check_standards/12_focusable_controls.feature
+++ b/features/check_standards/12_focusable_controls.feature
@@ -42,7 +42,7 @@ Feature: Focusable Controls
           <li><a href="#entertainmenttab">Entertainment</a></li>
       </ul>
       """
-    When I validate the "Focusable controls: anchors must have hrefs" standard
+    When I validate the "Focusable Controls: Anchors must have hrefs" standard
     Then it passes
 
   Scenario: Some anchor tags do not have href attributes
@@ -54,7 +54,7 @@ Feature: Focusable Controls
           <li><a>Entertainment</a></li>
       </ul>
       """
-    When I validate the "Focusable controls: anchors must have hrefs" standard
+    When I validate the "Focusable Controls: Anchors must have hrefs" standard
     Then it fails with the message:
       """
       Anchor has no href attribute: /html/body/ul/li[1]/a

--- a/features/check_standards/18_image_alternatives.feature
+++ b/features/check_standards/18_image_alternatives.feature
@@ -1,4 +1,4 @@
-Feature: Image Alternatives
+Feature: Image alternatives
 
   All images **must** have an alt attribute.
 
@@ -23,7 +23,7 @@ Feature: Image Alternatives
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" alt="" />
       """
-    When I validate the "Image Alternatives: Images must have alt attributes" standard
+    When I validate the "Image alternatives: Images must have alt attributes" standard
     Then it passes
 
   Scenario: Images without alt attributes
@@ -32,7 +32,7 @@ Feature: Image Alternatives
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" />
       """
-    When I validate the "Image Alternatives: Images must have alt attributes" standard
+    When I validate the "Image alternatives: Images must have alt attributes" standard
     Then it fails with the message:
       """
       Image has no alt attribute: /html/body/img[2]

--- a/features/check_standards/18_image_alternatives.feature
+++ b/features/check_standards/18_image_alternatives.feature
@@ -23,7 +23,7 @@ Feature: Image Alternatives
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" alt="" />
       """
-    When I validate the "Image alternatives: images must have alt attributes" standard
+    When I validate the "Image Alternatives: Images must have alt attributes" standard
     Then it passes
 
   Scenario: Images without alt attributes
@@ -32,7 +32,7 @@ Feature: Image Alternatives
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" />
       """
-    When I validate the "Image alternatives: images must have alt attributes" standard
+    When I validate the "Image Alternatives: Images must have alt attributes" standard
     Then it fails with the message:
       """
       Image has no alt attribute: /html/body/img[2]

--- a/features/check_standards/19_form_labels.feature
+++ b/features/check_standards/19_form_labels.feature
@@ -1,4 +1,4 @@
-Feature: Form Labels
+Feature: Form labels
 
   Form fields that allow input (`select`, and `textarea` elements, and all
   `input` element types other than image, submit, reset, button, or hidden)
@@ -16,7 +16,7 @@ Feature: Form Labels
   not supported in all versions of assistive technologies that BBC users could
   reasonably expect to be able to use.
 
-  Scenario: All fields have labels or title attributes
+  Scenario: All fields have labels or Title attributes
     Given a page with the body:
       """
       <label for="search">Search the BBC</label>
@@ -29,10 +29,10 @@ Feature: Form Labels
 
       <input type="text" name="q" title="Search the BBC" />
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Some fields without labels or title attributes
+  Scenario: Some fields without labels or Title attributes
     Given a page with the body:
       """
       <input type="text" name="name" title="Name" />
@@ -44,7 +44,7 @@ Feature: Form Labels
       <input type="text" name="q" aria-label="Search the BBC" />
       <input type="text" name="q" placeholder="Search the BBC" />
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it fails with the message:
       """
       Field has no label or title attribute: /html/body/textarea
@@ -54,12 +54,12 @@ Feature: Form Labels
       Field has no label or title attribute: /html/body/input[5]
       """
 
-  Scenario: Hidden fields do not need labels or title attributes
+  Scenario: Hidden fields do not need labels or Title attributes
     Given a page with the body:
       """
       <input type=hidden name=a value=b>
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Submit buttons do not need Title attributes or labels
@@ -67,47 +67,47 @@ Feature: Form Labels
       """
       <input type=submit name=a value=b>
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Reset inputs do not need labels or title attributes
+  Scenario: Reset inputs do not need labels or Title attributes
     Given a page with the body:
       """
       <input type=reset name=a value=b>
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Submit inputs do not need labels or title attributes
+  Scenario: Submit inputs do not need labels or Title attributes
     Given a page with the body:
       """
       <input type="submit" />
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Reset inputs do not need labels or title attributes
+  Scenario: Reset inputs do not need labels or Title attributes
     Given a page with the body:
       """
       <input type="reset" />
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Image inputs do not need labels or title attributes
+  Scenario: Image inputs do not need labels or Title attributes
     Given a page with the body:
       """
       <input type="image" />
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Buttons do not need labels or title attributes
+  Scenario: Buttons do not need labels or Title attributes
     Given a page with the body:
       """
       <button>Boo</button>
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Buttons need text
@@ -115,7 +115,7 @@ Feature: Form Labels
       """
       <button></button>
       """
-    When I validate the "Form Labels: Fields must have labels or titles" standard
+    When I validate the "Form labels: Fields must have labels or titles" standard
     Then it fails with the message:
       """
       Button has no text: /html/body/button

--- a/features/check_standards/19_form_labels.feature
+++ b/features/check_standards/19_form_labels.feature
@@ -29,7 +29,7 @@ Feature: Form Labels
 
       <input type="text" name="q" title="Search the BBC" />
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Some fields without labels or title attributes
@@ -44,7 +44,7 @@ Feature: Form Labels
       <input type="text" name="q" aria-label="Search the BBC" />
       <input type="text" name="q" placeholder="Search the BBC" />
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it fails with the message:
       """
       Field has no label or title attribute: /html/body/textarea
@@ -59,15 +59,15 @@ Feature: Form Labels
       """
       <input type=hidden name=a value=b>
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
-  Scenario: Submit buttons do not need title attributes or labels
+  Scenario: Submit buttons do not need Title attributes or labels
     Given a page with the body:
       """
       <input type=submit name=a value=b>
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Reset inputs do not need labels or title attributes
@@ -75,7 +75,7 @@ Feature: Form Labels
       """
       <input type=reset name=a value=b>
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Submit inputs do not need labels or title attributes
@@ -83,7 +83,7 @@ Feature: Form Labels
       """
       <input type="submit" />
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Reset inputs do not need labels or title attributes
@@ -91,7 +91,7 @@ Feature: Form Labels
       """
       <input type="reset" />
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Image inputs do not need labels or title attributes
@@ -99,7 +99,7 @@ Feature: Form Labels
       """
       <input type="image" />
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Buttons do not need labels or title attributes
@@ -107,7 +107,7 @@ Feature: Form Labels
       """
       <button>Boo</button>
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it passes
 
   Scenario: Buttons need text
@@ -115,7 +115,7 @@ Feature: Form Labels
       """
       <button></button>
       """
-    When I validate the "Form labels: fields must have labels or titles" standard
+    When I validate the "Form Labels: Fields must have labels or titles" standard
     Then it fails with the message:
       """
       Button has no text: /html/body/button

--- a/features/check_standards/20_form_interactions.feature
+++ b/features/check_standards/20_form_interactions.feature
@@ -27,7 +27,7 @@ Feature: Form Interactions
         <input type="submit" value="Search">
       </form>
       """
-    When I validate the "Form interactions: forms must have submit buttons" standard
+    When I validate the "Form Interactions: Forms must have submit buttons" standard
     Then it passes
 
   Scenario: Form with an image input
@@ -39,7 +39,7 @@ Feature: Form Interactions
         <input type="image" src="some.png">
       </form>
       """
-    When I validate the "Form interactions: forms must have submit buttons" standard
+    When I validate the "Form Interactions: Forms must have submit buttons" standard
     Then it passes
 
   Scenario: Form with no submit button
@@ -50,7 +50,7 @@ Feature: Form Interactions
         <input type="text" name="q" id="q">
       </form>
       """
-    When I validate the "Form interactions: forms must have submit buttons" standard
+    When I validate the "Form Interactions: Forms must have submit buttons" standard
     Then it fails with the message:
       """
       Form has no submit button: /html/body/form
@@ -65,5 +65,5 @@ Feature: Form Interactions
         <button type="submit">Search</button>
       </form>
       """
-    When I validate the "Form interactions: forms must have submit buttons" standard
+    When I validate the "Form Interactions: Forms must have submit buttons" standard
     Then it passes

--- a/features/check_standards/20_form_interactions.feature
+++ b/features/check_standards/20_form_interactions.feature
@@ -1,4 +1,4 @@
-Feature: Form Interactions
+Feature: Form interactions
 
   Forms must have a submit button and forms must not update the location of the
   page on change, focus, or blur events.
@@ -27,7 +27,7 @@ Feature: Form Interactions
         <input type="submit" value="Search">
       </form>
       """
-    When I validate the "Form Interactions: Forms must have submit buttons" standard
+    When I validate the "Form interactions: Forms must have submit buttons" standard
     Then it passes
 
   Scenario: Form with an image input
@@ -39,7 +39,7 @@ Feature: Form Interactions
         <input type="image" src="some.png">
       </form>
       """
-    When I validate the "Form Interactions: Forms must have submit buttons" standard
+    When I validate the "Form interactions: Forms must have submit buttons" standard
     Then it passes
 
   Scenario: Form with no submit button
@@ -50,7 +50,7 @@ Feature: Form Interactions
         <input type="text" name="q" id="q">
       </form>
       """
-    When I validate the "Form Interactions: Forms must have submit buttons" standard
+    When I validate the "Form interactions: Forms must have submit buttons" standard
     Then it fails with the message:
       """
       Form has no submit button: /html/body/form
@@ -65,5 +65,5 @@ Feature: Form Interactions
         <button type="submit">Search</button>
       </form>
       """
-    When I validate the "Form Interactions: Forms must have submit buttons" standard
+    When I validate the "Form interactions: Forms must have submit buttons" standard
     Then it passes

--- a/features/cli/display_result_summary.feature
+++ b/features/cli/display_result_summary.feature
@@ -7,7 +7,7 @@ Feature: Display result summary
       page("http://localhost:54321/perfect.html")
       page("http://localhost:54321/missing_main_heading.html")
       page("http://localhost:54321/missing_main_heading.html?again!", {
-        skip: "Headings: exactly one main heading"
+        skip: "Headings: Exactly one main heading"
       })
       """
     When I run `bbc-a11y`

--- a/features/cli/json_reporter.feature
+++ b/features/cli/json_reporter.feature
@@ -21,7 +21,7 @@ Feature: JSON Reporter
               "results": [
                 {
                   "standard": {
-                    "section": "focusableControls",
+                    "section": "Focusable Controls",
                     "name": "Anchors must have hrefs"
                   },
                   "errors": [],
@@ -29,7 +29,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "formInteractions",
+                    "section": "Form Interactions",
                     "name": "Forms must have submit buttons"
                   },
                   "errors": [],
@@ -37,7 +37,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "formLabels",
+                    "section": "Form Labels",
                     "name": "Fields must have labels or titles"
                   },
                   "errors": [],
@@ -45,7 +45,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "headings",
+                    "section": "Headings",
                     "name": "Content must follow headings"
                   },
                   "errors": [],
@@ -53,7 +53,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "headings",
+                    "section": "Headings",
                     "name": "Exactly one main heading"
                   },
                   "errors": [],
@@ -61,7 +61,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "headings",
+                    "section": "Headings",
                     "name": "Headings must be in ascending order"
                   },
                   "errors": [],
@@ -69,7 +69,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "imageAlternatives",
+                    "section": "Image Alternatives",
                     "name": "Images must have alt attributes"
                   },
                   "errors": [],
@@ -77,7 +77,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "indicatingLanguage",
+                    "section": "Indicating Language",
                     "name": "Html must have lang attribute"
                   },
                   "errors": [],
@@ -85,7 +85,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "mainLandmark",
+                    "section": "Main Landmark",
                     "name": "Exactly one main landmark"
                   },
                   "errors": [],
@@ -93,7 +93,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "minimumTextSize",
+                    "section": "Minimum Text Size",
                     "name": "Text cannot be too small"
                   },
                   "errors": [],
@@ -101,7 +101,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "tabIndex",
+                    "section": "Tab Index",
                     "name": "Zero tab index must only be set on elements which are focusable by default"
                   },
                   "errors": [],
@@ -109,7 +109,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "titleAttributes",
+                    "section": "Title Attributes",
                     "name": "Title attributes must not duplicate content"
                   },
                   "errors": [],
@@ -117,7 +117,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "titleAttributes",
+                    "section": "Title Attributes",
                     "name": "Title attributes only on inputs"
                   },
                   "errors": [],
@@ -133,7 +133,7 @@ Feature: JSON Reporter
               "results": [
                 {
                   "standard": {
-                    "section": "focusableControls",
+                    "section": "Focusable Controls",
                     "name": "Anchors must have hrefs"
                   },
                   "errors": [],
@@ -141,7 +141,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "formInteractions",
+                    "section": "Form Interactions",
                     "name": "Forms must have submit buttons"
                   },
                   "errors": [],
@@ -149,7 +149,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "formLabels",
+                    "section": "Form Labels",
                     "name": "Fields must have labels or titles"
                   },
                   "errors": [],
@@ -157,7 +157,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "headings",
+                    "section": "Headings",
                     "name": "Content must follow headings"
                   },
                   "errors": [],
@@ -165,7 +165,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "headings",
+                    "section": "Headings",
                     "name": "Exactly one main heading"
                   },
                   "errors": [
@@ -177,7 +177,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "headings",
+                    "section": "Headings",
                     "name": "Headings must be in ascending order"
                   },
                   "errors": [],
@@ -185,7 +185,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "imageAlternatives",
+                    "section": "Image Alternatives",
                     "name": "Images must have alt attributes"
                   },
                   "errors": [],
@@ -193,7 +193,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "indicatingLanguage",
+                    "section": "Indicating Language",
                     "name": "Html must have lang attribute"
                   },
                   "errors": [],
@@ -201,7 +201,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "mainLandmark",
+                    "section": "Main Landmark",
                     "name": "Exactly one main landmark"
                   },
                   "errors": [],
@@ -209,7 +209,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "minimumTextSize",
+                    "section": "Minimum Text Size",
                     "name": "Text cannot be too small"
                   },
                   "errors": [],
@@ -217,7 +217,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "tabIndex",
+                    "section": "Tab Index",
                     "name": "Zero tab index must only be set on elements which are focusable by default"
                   },
                   "errors": [],
@@ -225,7 +225,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "titleAttributes",
+                    "section": "Title Attributes",
                     "name": "Title attributes must not duplicate content"
                   },
                   "errors": [],
@@ -233,7 +233,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "titleAttributes",
+                    "section": "Title Attributes",
                     "name": "Title attributes only on inputs"
                   },
                   "errors": [],

--- a/features/cli/json_reporter.feature
+++ b/features/cli/json_reporter.feature
@@ -21,7 +21,7 @@ Feature: JSON Reporter
               "results": [
                 {
                   "standard": {
-                    "section": "Focusable Controls",
+                    "section": "Focusable controls",
                     "name": "Anchors must have hrefs"
                   },
                   "errors": [],
@@ -29,7 +29,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Form Interactions",
+                    "section": "Form interactions",
                     "name": "Forms must have submit buttons"
                   },
                   "errors": [],
@@ -37,7 +37,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Form Labels",
+                    "section": "Form labels",
                     "name": "Fields must have labels or titles"
                   },
                   "errors": [],
@@ -69,7 +69,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Image Alternatives",
+                    "section": "Image alternatives",
                     "name": "Images must have alt attributes"
                   },
                   "errors": [],
@@ -77,7 +77,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Indicating Language",
+                    "section": "Indicating language",
                     "name": "Html must have lang attribute"
                   },
                   "errors": [],
@@ -85,15 +85,15 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Main Landmark",
-                    "name": "Exactly one main landmark"
+                    "section": "Main landmark",
+                    "name": "Exactly one Main landmark"
                   },
                   "errors": [],
                   "hiddenErrors": []
                 },
                 {
                   "standard": {
-                    "section": "Minimum Text Size",
+                    "section": "Minimum text size",
                     "name": "Text cannot be too small"
                   },
                   "errors": [],
@@ -101,15 +101,15 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Tab Index",
-                    "name": "Zero tab index must only be set on elements which are focusable by default"
+                    "section": "Tab index",
+                    "name": "Zero Tab index must only be set on elements which are focusable by default"
                   },
                   "errors": [],
                   "hiddenErrors": []
                 },
                 {
                   "standard": {
-                    "section": "Title Attributes",
+                    "section": "Title attributes",
                     "name": "Title attributes must not duplicate content"
                   },
                   "errors": [],
@@ -117,7 +117,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Title Attributes",
+                    "section": "Title attributes",
                     "name": "Title attributes only on inputs"
                   },
                   "errors": [],
@@ -133,7 +133,7 @@ Feature: JSON Reporter
               "results": [
                 {
                   "standard": {
-                    "section": "Focusable Controls",
+                    "section": "Focusable controls",
                     "name": "Anchors must have hrefs"
                   },
                   "errors": [],
@@ -141,7 +141,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Form Interactions",
+                    "section": "Form interactions",
                     "name": "Forms must have submit buttons"
                   },
                   "errors": [],
@@ -149,7 +149,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Form Labels",
+                    "section": "Form labels",
                     "name": "Fields must have labels or titles"
                   },
                   "errors": [],
@@ -185,7 +185,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Image Alternatives",
+                    "section": "Image alternatives",
                     "name": "Images must have alt attributes"
                   },
                   "errors": [],
@@ -193,7 +193,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Indicating Language",
+                    "section": "Indicating language",
                     "name": "Html must have lang attribute"
                   },
                   "errors": [],
@@ -201,15 +201,15 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Main Landmark",
-                    "name": "Exactly one main landmark"
+                    "section": "Main landmark",
+                    "name": "Exactly one Main landmark"
                   },
                   "errors": [],
                   "hiddenErrors": []
                 },
                 {
                   "standard": {
-                    "section": "Minimum Text Size",
+                    "section": "Minimum text size",
                     "name": "Text cannot be too small"
                   },
                   "errors": [],
@@ -217,15 +217,15 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Tab Index",
-                    "name": "Zero tab index must only be set on elements which are focusable by default"
+                    "section": "Tab index",
+                    "name": "Zero Tab index must only be set on elements which are focusable by default"
                   },
                   "errors": [],
                   "hiddenErrors": []
                 },
                 {
                   "standard": {
-                    "section": "Title Attributes",
+                    "section": "Title attributes",
                     "name": "Title attributes must not duplicate content"
                   },
                   "errors": [],
@@ -233,7 +233,7 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
-                    "section": "Title Attributes",
+                    "section": "Title attributes",
                     "name": "Title attributes only on inputs"
                   },
                   "errors": [],

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -5,7 +5,7 @@ Feature: Skipping Standards
     And a file named "a11y.js" with:
       """
       page("http://localhost:54321/missing_main_heading.html", {
-        skip: "Headings: exactly one main heading"
+        skip: "Headings: Exactly one main heading"
       })
       """
     When I run `bbc-a11y`
@@ -19,7 +19,7 @@ Feature: Skipping Standards
     And a file named "a11y.js" with:
       """
       page("http://localhost:54321/two_headings_failures.html", {
-        only: "Headings: exactly one main heading"
+        only: "Headings: Exactly one main heading"
       })
       """
     When I run `bbc-a11y`

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -91,8 +91,9 @@ defineSupportCode(function({ Given, When, Then }) {
 
   When('I validate the {name:stringInDoubleQuotes} standard', function (name) {
     var $ = jquery(this.pageFrame.contentDocument)
-    var standards = Standards.matching(name)
-    this.validationResult = standards.validate($.find.bind($))
+    var matching = Standards.matching(name)
+    if (matching.standards.length != 1) throw new Error("Expected 1 standard called '" + name + "', found " + matching.standards.length)
+    this.validationResult = matching.validate($.find.bind($))
   })
 
   Then('it passes', function () {

--- a/features/testing_iframes.feature
+++ b/features/testing_iframes.feature
@@ -7,7 +7,7 @@ Feature: Testing iframes
       <h1>This frame has no main heading:</h1>
       <iframe src="http://localhost:54321/missing_main_heading.html"></iframe>
       """
-    When I validate the "Headings: exactly one main heading" standard
+    When I validate the "Headings: Exactly one main heading" standard
     Then it fails with the message:
       """
       In frame /html/body/iframe : Found 0 h1 elements.
@@ -20,7 +20,7 @@ Feature: Testing iframes
       <h1>This frame has no main heading:</h1>
       <iframe src="http://localhost:54321/iframe.html"></iframe>
       """
-    When I validate the "Headings: exactly one main heading" standard
+    When I validate the "Headings: Exactly one main heading" standard
     Then it fails with the message:
       """
       In frame /html/body/iframe : Found 0 h1 elements.
@@ -34,7 +34,7 @@ Feature: Testing iframes
       <h1>This frame has no main heading:</h1>
       <iframe src="http://127.0.0.1:54321/iframe.html"></iframe>
       """
-    When I validate the "Headings: exactly one main heading" standard
+    When I validate the "Headings: Exactly one main heading" standard
     Then it fails with the message:
       """
       In frame /html/body/iframe : Found 0 h1 elements.

--- a/guides/using/coverage.md
+++ b/guides/using/coverage.md
@@ -19,13 +19,13 @@ a summary of those standards and the level of test coverage currently provided.
 | Resizable text          |     x     |        x       |    x   |
 | Tabindex                |    yes    |        x       |    x   |
 | Title attributes        |    yes    |        x       |    x   |
-| Focusable Controls      |    yes    |        x       |    x   |
+| Focusable controls      |    yes    |        x       |    x   |
 | Visible on focus        |     x     |        x       |    x   |
 | Control styles          |     x     |        x       |    x   |
 | Focus styles            |     x     |        x       |    x   |
 | Colour contrast         |     x     |        x       |    x   |
 | Colour and meaning      |     x     |        x       |    x   |
-| Image Alternatives      |    yes    |        x       |    x   |
+| Image alternatives      |    yes    |        x       |    x   |
 | Form labels             |    yes    |        x       |    x   |
 | Form interactions       |    yes    |        x       |    x   |
 | Tables                  |     x     |        x       |    x   |

--- a/guides/using/coverage.md
+++ b/guides/using/coverage.md
@@ -19,13 +19,13 @@ a summary of those standards and the level of test coverage currently provided.
 | Resizable text          |     x     |        x       |    x   |
 | Tabindex                |    yes    |        x       |    x   |
 | Title attributes        |    yes    |        x       |    x   |
-| Focusable controls      |    yes    |        x       |    x   |
+| Focusable Controls      |    yes    |        x       |    x   |
 | Visible on focus        |     x     |        x       |    x   |
 | Control styles          |     x     |        x       |    x   |
 | Focus styles            |     x     |        x       |    x   |
 | Colour contrast         |     x     |        x       |    x   |
 | Colour and meaning      |     x     |        x       |    x   |
-| Image alternatives      |    yes    |        x       |    x   |
+| Image Alternatives      |    yes    |        x       |    x   |
 | Form labels             |    yes    |        x       |    x   |
 | Form interactions       |    yes    |        x       |    x   |
 | Tables                  |     x     |        x       |    x   |

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -73,8 +73,8 @@ checks.
 ```js
 page("http://bbc.co.uk", {
   skip: [
-    'Focusable controls: Anchors must have hrefs',
-    'Headings: exactly one main heading'
+    'Focusable Controls: Anchors must have hrefs',
+    'Headings: Exactly one main heading'
   ]
 })
 
@@ -86,7 +86,7 @@ use `only` when you want to focus your attention on just one problem:
 
 ```js
 page("http://bbc.co.uk", {
-  only: 'Focusable controls: Anchors must have hrefs'
+  only: 'Focusable Controls: Anchors must have hrefs'
 })
 ```
 

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -73,7 +73,7 @@ checks.
 ```js
 page("http://bbc.co.uk", {
   skip: [
-    'Focusable Controls: Anchors must have hrefs',
+    'Focusable controls: Anchors must have hrefs',
     'Headings: Exactly one main heading'
   ]
 })
@@ -86,7 +86,7 @@ use `only` when you want to focus your attention on just one problem:
 
 ```js
 page("http://bbc.co.uk", {
-  only: 'Focusable Controls: Anchors must have hrefs'
+  only: 'Focusable controls: Anchors must have hrefs'
 })
 ```
 

--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -38,7 +38,7 @@ PrettyReporter.prototype.pageFailed = function(page, validationResult) {
     var result = validationResult.results[i]
     if (result.errors.length > 0) {
       this.summary.errorsFound += result.errors.length
-      this.commandLineConsole.log('  * ' + humanise(result.standard.section) + ': ' + result.standard.name)
+      this.commandLineConsole.log('  * ' + result.standard.section + ': ' + result.standard.name)
     }
     for (var j = 0; j < result.errors.length; j++) {
       var args = [result.standard.name + "\n"].concat(result.errors[j].map(function(a) {
@@ -97,10 +97,6 @@ PrettyReporter.prototype.configError = function(error) {
 
 function pluralise(count, str) {
   return count + ' ' + (count == 1 ? str : str + 's')
-}
-
-function humanise(str) {
-  return str[0].toUpperCase() + str.substr(1).replace(/[A-Z]/g, function(c) { return ' ' + c })
 }
 
 module.exports = PrettyReporter

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -8,58 +8,78 @@ function Standards(standards, skipped, hide) {
 
 Standards.sections = {
 
-  focusableControls: [
-    require('./focusableControls/anchorsMustHaveHrefs')
-  ],
+  focusableControls: {
+    tests: [
+      require('./focusableControls/anchorsMustHaveHrefs')
+    ]
+  },
 
-  formInteractions: [
-    require('./formInteractions/formsMustHaveSubmitButtons')
-  ],
+  formInteractions: {
+    tests: [
+      require('./formInteractions/formsMustHaveSubmitButtons')
+    ]
+  },
 
-  formLabels: [
-    require('./formLabels/fieldsMustHaveLabelsOrTitles')
-  ],
+  formLabels: {
+    tests: [
+      require('./formLabels/fieldsMustHaveLabelsOrTitles')
+    ]
+  },
 
-  headings: [
-    require('./headings/contentMustFollowHeadings'),
-    require('./headings/exactlyOneMainHeading'),
-    require('./headings/headingsMustBeInAscendingOrder')
-  ],
+  headings: {
+    tests: [
+      require('./headings/contentMustFollowHeadings'),
+      require('./headings/exactlyOneMainHeading'),
+      require('./headings/headingsMustBeInAscendingOrder')
+    ]
+  },
 
-  imageAlternatives: [
-    require('./imageAlternatives/imagesMustHaveAltAttributes'),
-  ],
+  imageAlternatives: {
+    tests: [
+      require('./imageAlternatives/imagesMustHaveAltAttributes'),
+    ]
+  },
 
-  indicatingLanguage: [
-    require('./indicatingLanguage/htmlMustHaveLangAttribute')
-  ],
+  indicatingLanguage: {
+    tests: [
+      require('./indicatingLanguage/htmlMustHaveLangAttribute')
+    ]
+  },
 
-  mainLandmark: [
-    require('./mainLandmark/exactlyOneMainLandmark')
-  ],
+  mainLandmark: {
+    tests: [
+      require('./mainLandmark/exactlyOneMainLandmark')
+    ]
+  },
 
-  minimumTextSize: [
-    require('./minimumTextSize/textCannotBeTooSmall')
-  ],
+  minimumTextSize: {
+    tests: [
+      require('./minimumTextSize/textCannotBeTooSmall')
+    ]
+  },
 
-  tabIndex: [
-    require('./tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault')
-  ],
+  tabIndex: {
+    tests: [
+      require('./tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault')
+    ]
+  },
 
-  titleAttributes: [
-    require('./titleAttributes/titleAttributesMustNotDuplicateContent'),
-    require('./titleAttributes/titleAttributesOnlyOnInputs')
-  ]
+  titleAttributes: {
+    tests: [
+      require('./titleAttributes/titleAttributesMustNotDuplicateContent'),
+      require('./titleAttributes/titleAttributesOnlyOnInputs')
+    ]
+  }
 
 }
 
 Standards.all = [];
 
 for (var section in Standards.sections) {
-  var sectionStandards = Standards.sections[section];
+  var sectionStandards = Standards.sections[section].tests;
   for (var i = 0; i < sectionStandards.length; ++i) {
     sectionStandards[i].section = section;
-    Standards.all.push(sectionStandards[i]);
+    Standards.all = Standards.all.concat(sectionStandards[i]);
   }
 }
 

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -9,24 +9,28 @@ function Standards(standards, skipped, hide) {
 Standards.sections = {
 
   focusableControls: {
+    title: 'Focusable Controls',
     tests: [
       require('./focusableControls/anchorsMustHaveHrefs')
     ]
   },
 
   formInteractions: {
+    title: 'Form Interactions',
     tests: [
       require('./formInteractions/formsMustHaveSubmitButtons')
     ]
   },
 
   formLabels: {
+    title: 'Form Labels',
     tests: [
       require('./formLabels/fieldsMustHaveLabelsOrTitles')
     ]
   },
 
   headings: {
+    title: 'Headings',
     tests: [
       require('./headings/contentMustFollowHeadings'),
       require('./headings/exactlyOneMainHeading'),
@@ -35,36 +39,42 @@ Standards.sections = {
   },
 
   imageAlternatives: {
+    title: 'Image Alternatives',
     tests: [
       require('./imageAlternatives/imagesMustHaveAltAttributes'),
     ]
   },
 
   indicatingLanguage: {
+    title: 'Indicating Language',
     tests: [
       require('./indicatingLanguage/htmlMustHaveLangAttribute')
     ]
   },
 
   mainLandmark: {
+    title: 'Main Landmark',
     tests: [
       require('./mainLandmark/exactlyOneMainLandmark')
     ]
   },
 
   minimumTextSize: {
+    title: 'Minimum Text Size',
     tests: [
       require('./minimumTextSize/textCannotBeTooSmall')
     ]
   },
 
   tabIndex: {
+    title: 'Tab Index',
     tests: [
       require('./tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault')
     ]
   },
 
   titleAttributes: {
+    title: 'Title Attributes',
     tests: [
       require('./titleAttributes/titleAttributesMustNotDuplicateContent'),
       require('./titleAttributes/titleAttributesOnlyOnInputs')
@@ -78,7 +88,7 @@ Standards.all = [];
 for (var section in Standards.sections) {
   var sectionStandards = Standards.sections[section].tests;
   for (var i = 0; i < sectionStandards.length; ++i) {
-    sectionStandards[i].section = section;
+    sectionStandards[i].section = Standards.sections[section];
     Standards.all = Standards.all.concat(sectionStandards[i]);
   }
 }
@@ -93,7 +103,7 @@ Standards.prototype.validate = function(jquery) {
     standard = this.standards[i];
     standardResult = {
       standard: {
-        section: this.standards[i].section,
+        section: this.standards[i].section.title,
         name: this.standards[i].name
       },
       errors: []
@@ -152,18 +162,12 @@ Standards.matching = function(criteria) {
 
 function standardsMatching(criteria) {
   var skips = criteria.skip || [];
-  for (var i = 0; i < skips.length; ++i) {
-    skips[i] = normaliseStandardName(skips[i]);
-  }
   var onlies = criteria.only || [];
-  for (var i = 0; i < onlies.length; ++i) {
-    onlies[i] = normaliseStandardName(onlies[i]);
-  }
   var matches = [];
   var skipped = [];
   for (var i = 0; i < Standards.all.length; ++i) {
     var standard = Standards.all[i];
-    var name = standard.section.toLowerCase() + normaliseStandardName(standard.name);
+    var name = standard.section.title + ': ' + standard.name;
     if (onlies.length > 0) {
       if (onlies.indexOf(name) > -1) {
         matches.push(standard);
@@ -179,8 +183,5 @@ function standardsMatching(criteria) {
   return { matches: matches, skipped: skipped };
 }
 
-function normaliseStandardName(name) {
-  return name.replace(/\W+/g, '').toLowerCase();
-}
 
 module.exports = Standards;

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -9,21 +9,21 @@ function Standards(standards, skipped, hide) {
 Standards.sections = {
 
   focusableControls: {
-    title: 'Focusable Controls',
+    title: 'Focusable controls',
     tests: [
       require('./focusableControls/anchorsMustHaveHrefs')
     ]
   },
 
   formInteractions: {
-    title: 'Form Interactions',
+    title: 'Form interactions',
     tests: [
       require('./formInteractions/formsMustHaveSubmitButtons')
     ]
   },
 
   formLabels: {
-    title: 'Form Labels',
+    title: 'Form labels',
     tests: [
       require('./formLabels/fieldsMustHaveLabelsOrTitles')
     ]
@@ -39,42 +39,42 @@ Standards.sections = {
   },
 
   imageAlternatives: {
-    title: 'Image Alternatives',
+    title: 'Image alternatives',
     tests: [
       require('./imageAlternatives/imagesMustHaveAltAttributes'),
     ]
   },
 
   indicatingLanguage: {
-    title: 'Indicating Language',
+    title: 'Indicating language',
     tests: [
       require('./indicatingLanguage/htmlMustHaveLangAttribute')
     ]
   },
 
   mainLandmark: {
-    title: 'Main Landmark',
+    title: 'Main landmark',
     tests: [
       require('./mainLandmark/exactlyOneMainLandmark')
     ]
   },
 
   minimumTextSize: {
-    title: 'Minimum Text Size',
+    title: 'Minimum text size',
     tests: [
       require('./minimumTextSize/textCannotBeTooSmall')
     ]
   },
 
   tabIndex: {
-    title: 'Tab Index',
+    title: 'Tab index',
     tests: [
       require('./tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault')
     ]
   },
 
   titleAttributes: {
-    title: 'Title Attributes',
+    title: 'Title attributes',
     tests: [
       require('./titleAttributes/titleAttributesMustNotDuplicateContent'),
       require('./titleAttributes/titleAttributesOnlyOnInputs')

--- a/lib/standards/mainLandmark/exactlyOneMainLandmark.js
+++ b/lib/standards/mainLandmark/exactlyOneMainLandmark.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'Exactly one main landmark',
+  name: 'Exactly one Main landmark',
 
   validate: function($, fail) {
     var mainLandmarks = $("[role='main']");

--- a/lib/standards/tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault.js
+++ b/lib/standards/tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'Zero tab index must only be set on elements which are focusable by default',
+  name: 'Zero Tab index must only be set on elements which are focusable by default',
 
   validate: function($, fail) {
     var baddies = $("*[tabindex='0']:not(input, button, select, textarea, a)");

--- a/test/a11ySpec.js
+++ b/test/a11ySpec.js
@@ -22,7 +22,7 @@ describe('a11y', function() {
     var expectedErrors = [
       {
         "standard": {
-          "section": "headings",
+          "section": "Headings",
           "name": "Exactly one main heading"
         },
         "errors":[
@@ -32,7 +32,7 @@ describe('a11y', function() {
       },
       {
         "standard": {
-          "section": "indicatingLanguage",
+          "section": "Indicating Language",
           "name": "Html must have lang attribute"
         },
         "errors":[
@@ -42,7 +42,7 @@ describe('a11y', function() {
       },
       {
         "standard": {
-          "section": "mainLandmark",
+          "section": "Main Landmark",
           "name": "Exactly one main landmark"
         },
         "errors":[
@@ -55,7 +55,7 @@ describe('a11y', function() {
   })
 
   it('skips standards', function() {
-    var validation = a11y.validate({ skip: ['Main landmark: Exactly one main landmark'] })
+    var validation = a11y.validate({ skip: ['Main Landmark: Exactly one main landmark'] })
     expect(validation.skipped).to.eql(['Exactly one main landmark'])
   })
 
@@ -69,7 +69,7 @@ describe('a11y', function() {
   })
 
   it('only runs specific standards', function() {
-    var validation = a11y.validate({ only: ['Main landmark: Exactly one main landmark'] })
+    var validation = a11y.validate({ only: ['Main Landmark: Exactly one main landmark'] })
     expect(validation.results.length).to.equal(1)
     expect(validation.results[0].standard.name).to.equal('Exactly one main landmark')
   })

--- a/test/a11ySpec.js
+++ b/test/a11ySpec.js
@@ -32,7 +32,7 @@ describe('a11y', function() {
       },
       {
         "standard": {
-          "section": "Indicating Language",
+          "section": "Indicating language",
           "name": "Html must have lang attribute"
         },
         "errors":[
@@ -42,8 +42,8 @@ describe('a11y', function() {
       },
       {
         "standard": {
-          "section": "Main Landmark",
-          "name": "Exactly one main landmark"
+          "section": "Main landmark",
+          "name": "Exactly one Main landmark"
         },
         "errors":[
           ['Found 0 elements with role="main".']
@@ -55,8 +55,8 @@ describe('a11y', function() {
   })
 
   it('skips standards', function() {
-    var validation = a11y.validate({ skip: ['Main Landmark: Exactly one main landmark'] })
-    expect(validation.skipped).to.eql(['Exactly one main landmark'])
+    var validation = a11y.validate({ skip: ['Main landmark: Exactly one Main landmark'] })
+    expect(validation.skipped).to.eql(['Exactly one Main landmark'])
   })
 
   it('hides errors', function() {
@@ -69,8 +69,8 @@ describe('a11y', function() {
   })
 
   it('only runs specific standards', function() {
-    var validation = a11y.validate({ only: ['Main Landmark: Exactly one main landmark'] })
+    var validation = a11y.validate({ only: ['Main landmark: Exactly one Main landmark'] })
     expect(validation.results.length).to.equal(1)
-    expect(validation.results[0].standard.name).to.equal('Exactly one main landmark')
+    expect(validation.results[0].standard.name).to.equal('Exactly one Main landmark')
   })
 })

--- a/test/iframeSpec.js
+++ b/test/iframeSpec.js
@@ -26,7 +26,7 @@ describe('a11y validating in frames', function() {
     var validation = a11y.validate({ only: ['Headings: Exactly one main heading']})
     expect(validation.results).to.eql([{
       standard: {
-        section: 'headings',
+        section: 'Headings',
         name: 'Exactly one main heading',
       },
       errors: [

--- a/test/minimumTextSizeStandardSpec.js
+++ b/test/minimumTextSizeStandardSpec.js
@@ -2,7 +2,7 @@ var standard = require('../lib/standards/minimumTextSize/textCannotBeTooSmall')
 var $ = require('jquery')
 var expect = require('chai').expect
 
-describe('minimum text size standard', function() {
+describe('Minimum Text Size standard', function() {
   it('ignores text nodes with parents with display: none', function() {
     $('<div style="display:none font-size: 1px">Text!</div>').appendTo('body')
     var failures = []

--- a/test/minimumTextSizeStandardSpec.js
+++ b/test/minimumTextSizeStandardSpec.js
@@ -2,7 +2,7 @@ var standard = require('../lib/standards/minimumTextSize/textCannotBeTooSmall')
 var $ = require('jquery')
 var expect = require('chai').expect
 
-describe('Minimum Text Size standard', function() {
+describe('Minimum text size standard', function() {
   it('ignores text nodes with parents with display: none', function() {
     $('<div style="display:none font-size: 1px">Text!</div>').appendTo('body')
     var failures = []

--- a/test/standardsSpec.js
+++ b/test/standardsSpec.js
@@ -9,23 +9,23 @@ describe('Standards', function() {
     })
   })
 
-  describe('.matching("Focusable Controls: Anchors must have hrefs")', function() {
+  describe('.matching("Focusable controls: Anchors must have hrefs")', function() {
     it('finds standards matching the string', function() {
-      var matches = Standards.matching('Focusable Controls: Anchors must have hrefs')
+      var matches = Standards.matching('Focusable controls: Anchors must have hrefs')
       expect(matches.standards.length).to.equal(1)
     })
   })
 
-  describe('.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] })', function() {
+  describe('.matching({ skip: ["Focusable controls: Anchors must have hrefs"] })', function() {
     it('finds all standards except one', function() {
-      var matches = Standards.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] })
+      var matches = Standards.matching({ skip: ["Focusable controls: Anchors must have hrefs"] })
       expect(matches.standards.length).to.equal(Standards.all.length - 1)
     })
   })
 
-  describe('.matching({ only: ["Focusable Controls: Anchors must have hrefs"] })', function() {
+  describe('.matching({ only: ["Focusable controls: Anchors must have hrefs"] })', function() {
     it('finds one standard', function() {
-      var matches = Standards.matching({ only: ["Focusable Controls: Anchors must have hrefs"] })
+      var matches = Standards.matching({ only: ["Focusable controls: Anchors must have hrefs"] })
       expect(matches.standards.length).to.equal(1)
     })
   })

--- a/test/standardsSpec.js
+++ b/test/standardsSpec.js
@@ -1,31 +1,31 @@
-var standards = require('../lib/standards')
+var Standards = require('../lib/standards')
 var expect = require('chai').expect
 
-describe('standards', function() {
+describe('Standards', function() {
   describe('.matching(undefined)', function() {
     it('finds all standards', function() {
-      var matches = standards.matching()
-      expect(matches.standards.length).to.equal(standards.all.length)
+      var matches = Standards.matching()
+      expect(matches.standards.length).to.equal(Standards.all.length)
     })
   })
 
   describe('.matching("Focusable Controls: Anchors must have hrefs")', function() {
     it('finds standards matching the string', function() {
-      var matches = standards.matching('Focusable Controls: anchors must have hrefs')
+      var matches = Standards.matching('Focusable Controls: Anchors must have hrefs')
       expect(matches.standards.length).to.equal(1)
     })
   })
 
   describe('.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] })', function() {
     it('finds all standards except one', function() {
-      var matches = standards.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] })
-      expect(matches.standards.length).to.equal(standards.all.length - 1)
+      var matches = Standards.matching({ skip: ["Focusable Controls: Anchors must have hrefs"] })
+      expect(matches.standards.length).to.equal(Standards.all.length - 1)
     })
   })
 
-  describe('.matching({ only: ["Focusable controls: Anchors must have hrefs"] })', function() {
+  describe('.matching({ only: ["Focusable Controls: Anchors must have hrefs"] })', function() {
     it('finds one standard', function() {
-      var matches = standards.matching({ only: ["Focusable controls: Anchors must have hrefs"] })
+      var matches = Standards.matching({ only: ["Focusable Controls: Anchors must have hrefs"] })
       expect(matches.standards.length).to.equal(1)
     })
   })


### PR DESCRIPTION
Simplifies the code by introducing objects representing each section of the guidelines. That way we have a place to hang links, numbers, and other metadata for other forthcoming features.