### PR TITLE
Automate table standard

### DIFF
--- a/features/check_standards/21_tables.feature
+++ b/features/check_standards/21_tables.feature
@@ -1,1 +1,279 @@
 Feature: Tables
+
+  Data tables must be marked up in a way that enable browsers and assistive
+  technologies to identify them as such.
+
+  Rationale
+  =========
+
+  Assistive technologies such as screen readers identify HTML tables as being
+  either for data or for layout based on the markup used.
+
+  If a <table> is identified as a layout table then potentially useful
+  structures may be ignored.
+
+  Definitions
+  ===========
+
+  Algorithm
+  ---------
+
+  The following algorithm is used to determine if a <table> has been marked up
+  in a way that allows browsers and assistive technologies to identify it as a
+  data table:
+
+  * Table inside editable area is data table always since the table structure
+    is crucial for table editing
+
+  * Table having ARIA table related role is data table (like ARIA grid or
+    treegrid)
+
+  * Table having ARIA landmark role is data table
+
+  * Table having datatable="0" attribute is layout table
+
+  * Table created by CSS display style is layout table
+
+  * Table having summary attribute or legitimate data table structures is data
+    table; these structures are:
+
+    * <caption> element
+    * <col> or <colgroup> elements
+    * <tfoot> or <thead> elements
+    * <th> elements
+    * header, scope or abbr attributes on table cell
+    * abbr element as a single child element of table cell
+
+  * Table having nested table is layout table
+
+  * Table having only one row or column is layout table
+
+  * Table having many columns (>= 5) is data table
+
+  * Table having borders around cells is data table
+
+  * Table having differently colored rows is data table
+
+  * Table having many rows (>= 20) is data table
+
+  * Wide table (more than 95% of the document width) is layout table
+
+  * Table having small amount of cells (<= 10) is layout table
+
+  * Table containing <embed>, <object>, <applet> of iframe elements (typical
+    advertisements elements) is layout table
+
+  * Otherwise it’s data table
+
+  Go through each check in turn, stopping when you reach a data table or layout
+  table result.
+
+  Scenario: Data table
+    Given a page with the body:
+      """
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+        </tr>
+        <tr>
+          <td>7</td><td>8</td><td>9</td><td>10</td><td>11</td><td>12</td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it passes
+
+  Scenario: Table with datatable="0"
+    Given a page with the body:
+      """
+      <table datatable="0">
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+        </tr>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table
+      """
+
+  Scenario: Table created by CSS display style
+    Given a page with the body:
+      """
+      <div style="display:table">
+        This isn't a table, it's just made to look like one
+      </div>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/div
+      """
+
+  Scenario: Nested table
+    Given a page with the body:
+      """
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+        </tr>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+        </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+              </tr>
+              <tr>
+                <td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table
+      """
+
+  Scenario: Table with only one row and less than 5 columns
+    Given a page with the body:
+      """
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table
+      """
+
+  Scenario: Table with only one column
+    Given a page with the body:
+      """
+      <table>
+        <tr><td>1</td></tr>
+        <tr><td>2</td></tr>
+        <tr><td>3</td></tr>
+        <tr><td>4</td></tr>
+        <tr><td>5</td></tr>
+        <tr><td>6</td></tr>
+        <tr><td>7</td></tr>
+        <tr><td>8</td></tr>
+        <tr><td>9</td></tr>
+        <tr><td>10</td></tr>
+        <tr><td>11</td></tr>
+        <tr><td>12</td></tr>
+        <tr><td>13</td></tr>
+        <tr><td>14</td></tr>
+        <tr><td>15</td></tr>
+        <tr><td>16</td></tr>
+        <tr><td>17</td></tr>
+        <tr><td>18</td></tr>
+        <tr><td>19</td></tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table
+      """
+
+  Scenario: Wide table
+    Given a page with the body:
+      """
+      <!-- 110% to account for body padding -->
+      <table style="width:110%">
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table
+      """
+
+  Scenario: Table with few cells
+    Given a page with the body:
+      """
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td>
+        </tr>
+        <tr>
+          <td>4</td><td>5</td><td>6</td>
+        </tr>
+        <tr>
+          <td>7</td><td>8</td><td>9</td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table
+      """
+
+  Scenario: Tables with advertising elements
+    Given a page with the body:
+      """
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+        <tr>
+          <td>5</td><td>6</td><td>7</td><td>8</td>
+        </tr>
+        <tr>
+          <td>9</td><td>10</td><td>11</td><td><object /></td>
+        </tr>
+      </table>
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+        <tr>
+          <td>5</td><td>6</td><td>7</td><td>8</td>
+        </tr>
+        <tr>
+          <td>9</td><td>10</td><td>11</td><td><embed /></td>
+        </tr>
+      </table>
+      <table>
+        <tr>
+          <td>1</td><td>2</td><td>3</td><td>4</td>
+        </tr>
+        <tr>
+          <td>5</td><td>6</td><td>7</td><td>8</td>
+        </tr>
+        <tr>
+          <td>9</td><td>10</td><td>11</td><td><applet /></td>
+        </tr>
+      </table>
+      """
+    When I validate the "Tables: Use tables for data" standard
+    Then it fails with the message:
+      """
+      Table used for layout: /html/body/table[1]
+      Table used for layout: /html/body/table[2]
+      Table used for layout: /html/body/table[3]
+      """

--- a/features/cli/json_reporter.feature
+++ b/features/cli/json_reporter.feature
@@ -109,6 +109,14 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
+                    "section": "Tables",
+                    "name": "Use tables for data"
+                  },
+                  "errors": [],
+                  "hiddenErrors": []
+                },
+                {
+                  "standard": {
                     "section": "Title attributes",
                     "name": "Title attributes must not duplicate content"
                   },
@@ -227,6 +235,14 @@ Feature: JSON Reporter
                   "standard": {
                     "section": "Tab index",
                     "name": "Zero Tab index must only be set on elements which are focusable by default"
+                  },
+                  "errors": [],
+                  "hiddenErrors": []
+                },
+                {
+                  "standard": {
+                    "section": "Tables",
+                    "name": "Use tables for data"
                   },
                   "errors": [],
                   "hiddenErrors": []

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -135,7 +135,7 @@ defineSupportCode(function({ Given, When, Then }) {
         }).join(" ")
       }).join("\n");
     }).join("\n")
-    assert.equal(message, actualMessage)
+    assert.equal(actualMessage, message)
   })
 
   Then('the exit status should be {status:int}', function (status) {

--- a/lib/detectTableType.js
+++ b/lib/detectTableType.js
@@ -1,0 +1,48 @@
+var $ = require('jquery')
+
+function detectTableType(table) {
+  var $table = $(table)
+  if ($table.is(':not(table),[datatable=0]')) {
+    return 'layout'
+  }
+
+  if ($table.parents("[contenteditable=true]").length > 0 ||
+      $table.is('[role=grid],[role=treegrid],[role=landmark],[summary],:has(caption,col,colgroup,tfoot,thead,th,td[header],td[scope],td[abbr],td:has(>abbr:only-child))')) {
+    return 'data'
+  }
+
+  if ($table.is(':has(table)')) {
+    return 'layout'
+  }
+
+  var cells = $table.find('> tr > td, > tbody > tr > td')
+  var rows = $table.find('> tr, > tbody > tr')
+  var cols = Math.max.apply(null, rows.get().map(function(row) { return $(row).find('> td').length }))
+
+  if (cols >= 5 || rows.length >= 20 || cells.get().some(function(cell) { return $(cell).css('border-width') != '0px' })) {
+    return 'data'
+  }
+
+  if (rows.length == 1 || cols == 1) {
+    return 'layout'
+  }
+
+  var tableWidth = $(table).width()
+  var documentWidth = $(table.ownerDocument).width()
+  var percentOfDocumentWidth = (tableWidth / documentWidth) * 100
+  if (percentOfDocumentWidth > 95) {
+    return 'layout'
+  }
+
+  if (cells.length <= 10) {
+    return 'layout'
+  }
+
+  if ($table.is(':has(object,embed,applet)')) {
+    return 'layout'
+  }
+
+  return 'data'
+}
+
+module.exports = detectTableType

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -82,6 +82,14 @@ Standards.sections = {
     documentationUrl: 'http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tabindex.shtml'
   },
 
+  tables: {
+    title: 'Tables',
+    tests: [
+      require('./tables/useTablesForData')
+    ],
+    documentationUrl: 'http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tables.shtml'
+  },
+
   titleAttributes: {
     title: 'Title attributes',
     tests: [

--- a/lib/standards/tables/useTablesForData.js
+++ b/lib/standards/tables/useTablesForData.js
@@ -1,0 +1,18 @@
+var detectTableType = require('../../detectTableType')
+
+module.exports = {
+  name: 'Use tables for data',
+
+  validate: function($, fail) {
+    $('table').each(function() {
+      if (detectTableType(this) == 'layout') {
+        fail('Table used for layout:', this)
+      }
+    })
+    $(':not(table)').each(function() {
+      if ($(this).css('display') == 'table') {
+        fail('Table used for layout:', this)
+      }
+    })
+  }
+}

--- a/test/detectTableTypeSpec.js
+++ b/test/detectTableTypeSpec.js
@@ -1,0 +1,232 @@
+var detectTableType = require('../lib/detectTableType')
+var expect = require('chai').expect
+
+describe('detectTableType', function () {
+  var container, table
+
+  beforeEach(function () {
+
+    container = document.createElement('div')
+    table = document.createElement('table')
+    document.body.appendChild(container)
+    container.appendChild(table)
+  })
+
+  describe('a table inside editable area', function () {
+    it('is a data table', function () {
+      container.contentEditable = 'true'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with role="grid"', function () {
+    it('is a data table', function () {
+      table.setAttribute('role', 'grid')
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with role="treegrid"', function () {
+    it('is a data table', function () {
+      table.setAttribute('role', 'treegrid')
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with role="landmark"', function () {
+    it('is a data table', function () {
+      table.setAttribute('role', 'landmark')
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with datatable="0"', function () {
+    it('is a data table', function () {
+      table.setAttribute('datatable', '0')
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table created by CSS display style', function () {
+    it('is a data table', function () {
+      container.style.display = 'table'
+      expect(detectTableType(container)).to.equal('layout')
+    })
+  })
+
+  describe('a table with a summary attribute', function () {
+    it('is a data table', function () {
+      table.setAttribute('summary', 'tabular')
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <caption>', function () {
+    it('is a data table', function () {
+      table.appendChild(document.createElement('caption'))
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <col>', function () {
+    it('is a data table', function () {
+      table.appendChild(document.createElement('col'))
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <colgroup>', function () {
+    it('is a data table', function () {
+      table.appendChild(document.createElement('colgroup'))
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <tfoot>', function () {
+    it('is a data table', function () {
+      table.appendChild(document.createElement('tfoot'))
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <thead>', function () {
+    it('is a data table', function () {
+      table.appendChild(document.createElement('thead'))
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <th>', function () {
+    it('is a data table', function () {
+      table.appendChild(document.createElement('th'))
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <tr><td header="x">ok</td></tr>', function () {
+    it('is a data table', function () {
+      table.innerHTML = '<tr><td header="x">ok</td></tr>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <tr><td scope="x">ok</td></tr>', function () {
+    it('is a data table', function () {
+      table.innerHTML = '<tr><td scope="x">ok</td></tr>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <tr><td abbr="x">ok</td></tr>', function () {
+    it('is a data table', function () {
+      table.innerHTML = '<tr><td abbr="x">ok</td></tr>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with <tr><td><abbr>ok</abbr></td></tr>', function () {
+    it('is a data table', function () {
+      table.innerHTML = '<tr><td><abbr>ok</abbr></td></tr>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with a <tr><td><abbr>foo</abbr><p>bar</p></td></tr>', function () {
+    it('is a layout table', function () {
+      table.innerHTML = '<tr><td><abbr>foo</abbr><p>bar</p></td></tr>'
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table with a nested table', function () {
+    it('is a layout table', function () {
+      table.innerHTML = rowsWithTwoColumns(11) + '<tr><td><table /></td></tr>'
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table with 3 rows and 5 columns', function () {
+    it('is a data table', function () {
+      var rows = '<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>' +
+                 '<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>' +
+                 '<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>'
+      table.innerHTML = rows
+      expect(detectTableType(table)).to.equal('data')
+      table.innerHTML = '<tbody>' + rows + '</tbody>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with 1 column and 20 rows', function () {
+    it('is a data table', function () {
+      var rows = ''
+      for (var i = 0; i < 20; i++) { rows += '<tr><td>row</td></tr>' }
+      table.innerHTML = rows
+      expect(detectTableType(table)).to.equal('data')
+      table.innerHTML = '<tbody>' + rows + '</tbody>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a table with borders around cells', function () {
+    it('is a data table', function () {
+      table.innerHTML = '<tr><td style="border: 1px solid green">row</td></tr>'
+      expect(detectTableType(table)).to.equal('data')
+    })
+  })
+
+  describe('a wide table (> 95% document width)', function () {
+    it('is a layout table', function () {
+      var iframe = document.createElement('iframe')
+      document.body.appendChild(iframe)
+      iframe.contentDocument.write('<table>' + rowsWithTwoColumns(10) + '</table>')
+      iframe.contentDocument.body.style = 'padding: 0; margin: 0'
+      table = iframe.contentDocument.getElementsByTagName('table')[0]
+      expect(detectTableType(table)).to.equal('data')
+      table.style.width = '96%'
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table with 10 cells', function () {
+    it('is a layout table', function () {
+      table.innerHTML = rowsWithTwoColumns(6)
+      expect(detectTableType(table)).to.equal('data')
+      table.innerHTML = rowsWithTwoColumns(5)
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table with <tr><td><object /></td></tr>', function () {
+    it('is a layout table', function () {
+      table.innerHTML = rowsWithTwoColumns(6)
+      expect(detectTableType(table)).to.equal('data')
+      table.innerHTML = rowsWithTwoColumns(6) + '<tr><td><object /></td></tr>'
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table with <tr><td><embed /></td></tr>', function () {
+    it('is a layout table', function () {
+      table.innerHTML = rowsWithTwoColumns(6)
+      expect(detectTableType(table)).to.equal('data')
+      table.innerHTML = rowsWithTwoColumns(6) + '<tr><td><embed /></td></tr>'
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  describe('a table with <tr><td><applet /></td></tr>', function () {
+    it('is a layout table', function () {
+      table.innerHTML = rowsWithTwoColumns(6)
+      expect(detectTableType(table)).to.equal('data')
+      table.innerHTML = rowsWithTwoColumns(6) + '<tr><td><applet /></td></tr>'
+      expect(detectTableType(table)).to.equal('layout')
+    })
+  })
+
+  function rowsWithTwoColumns(n) {
+    var rows = ''
+    for (var i = 0; i < n; i++) { rows += '<tr><td>1</td><td>2</td></tr>' }
+    return rows
+  }
+})


### PR DESCRIPTION
Automates everything except from the [table standard](http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tables.shtml) except for "Table having differently colored rows is data table" 