### PR TITLE
Ignore invisible elements

### DIFF
--- a/features/check_standards/10_tab_index.feature
+++ b/features/check_standards/10_tab_index.feature
@@ -56,3 +56,14 @@ Feature: Tab index
       """
       Non-focusable element with tabindex=0: /html/body/div[2]
       """
+
+    Scenario: Unfocusable element with zero Tab index
+      Given a page with the body:
+        """
+        <a href="/news" tabindex="1">News</a>
+        <button type="submit" tabindex="2">Search</button>
+        <div tabindex="3"></div>
+        <div tabindex="0" style="display:none"></div>
+        """
+      When I validate the "Tab index: Zero Tab index must only be set on elements which are focusable by default" standard
+      Then it passes

--- a/features/check_standards/12_focusable_controls.feature
+++ b/features/check_standards/12_focusable_controls.feature
@@ -60,3 +60,11 @@ Feature: Focusable controls
       Anchor has no href attribute: /html/body/ul/li[1]/a
       Anchor has no href attribute: /html/body/ul/li[3]/a
       """
+
+  Scenario: Hidden anchor tag with no href attribute
+    Given a page with the body:
+      """
+      <a style="display:none">I'm invisible, ignore me</a>
+      """
+    When I validate the "Focusable controls: Anchors must have hrefs" standard
+    Then it passes

--- a/features/check_standards/19_form_labels.feature
+++ b/features/check_standards/19_form_labels.feature
@@ -54,6 +54,16 @@ Feature: Form labels
       Field has no label or title attribute: /html/body/input[5]
       """
 
+  Scenario: Hidden input fields
+    Given a page with the body:
+      """
+      <input type="text" name="name" style="display: none" />
+      <textarea name="text" style="display: none"></textarea>
+      <select name="select" style="display: none"></textarea>
+      """
+    When I validate the "Form labels: Fields must have labels or titles" standard
+    Then it passes
+
   Scenario: Hidden fields do not need labels or Title attributes
     Given a page with the body:
       """

--- a/features/check_standards/20_form_interactions.feature
+++ b/features/check_standards/20_form_interactions.feature
@@ -67,3 +67,14 @@ Feature: Form interactions
       """
     When I validate the "Form interactions: Forms must have submit buttons" standard
     Then it passes
+
+  Scenario: Hidden form with no submit button
+    Given a page with the body:
+      """
+      <form action="/search" style="display: none">
+        <label for="q">Search term:</label>
+        <input type="text" name="q" id="q">
+      </form>
+      """
+    When I validate the "Form interactions: Forms must have submit buttons" standard
+    Then it passes

--- a/lib/standards/focusableControls/anchorsMustHaveHrefs.js
+++ b/lib/standards/focusableControls/anchorsMustHaveHrefs.js
@@ -2,7 +2,7 @@ module.exports = {
   name: 'Anchors must have hrefs',
 
   validate: function($, fail) {
-    $("a:not([href])").each(function(index, anchor) {
+    $("a:not([href]):visible").each(function(index, anchor) {
       fail('Anchor has no href attribute:', anchor);
     });
   }

--- a/lib/standards/formInteractions/formsMustHaveSubmitButtons.js
+++ b/lib/standards/formInteractions/formsMustHaveSubmitButtons.js
@@ -2,7 +2,7 @@ module.exports = {
   name: 'Forms must have submit buttons',
 
   validate: function($, fail) {
-    $("form").each(function(index, form) {
+    $("form:visible").each(function(index, form) {
       var submits = $(form).find("input[type=submit], button[type=submit], input[type=image]");
       if (submits.length == 0) {
         fail('Form has no submit button:', form);

--- a/lib/standards/formLabels/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/formLabels/fieldsMustHaveLabelsOrTitles.js
@@ -15,8 +15,8 @@ module.exports = {
   name: 'Fields must have labels or titles',
 
   validate: function($, fail) {
-    $("input:not([title], [type='hidden'], [type='submit'], [type='reset'], [type='image']), " +
-      "textarea:not([title]), select:not([title])")
+    $("input:visible:not([title], [type='hidden'], [type='submit'], [type='reset'], [type='image']), " +
+      "textarea:visible:not([title]), select:visible:not([title])")
       .filter(function(index, field) {
         return !hasIdOrLabel($(field));
       })

--- a/lib/standards/tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault.js
+++ b/lib/standards/tabIndex/elementsWithZeroTabIndexMustBeFocusableByDefault.js
@@ -2,7 +2,7 @@ module.exports = {
   name: 'Zero Tab index must only be set on elements which are focusable by default',
 
   validate: function($, fail) {
-    var baddies = $("*[tabindex='0']:not(input, button, select, textarea, a)");
+    var baddies = $("*[tabindex='0']:visible:not(input, button, select, textarea, a)");
     baddies.each(function(index, el) {
       fail('Non-focusable element with tabindex=0:', el);
     });


### PR DESCRIPTION
Ignores invisible elements (e.g. style="display:none") in various standards checks