### PR TITLE
Don't report parent and child too small font

### DIFF
--- a/features/check_standards/08_minimum_text_size.feature
+++ b/features/check_standards/08_minimum_text_size.feature
@@ -30,8 +30,6 @@ Feature: Minimum text size
     Then it fails with the message:
       """
       Text size too small (10px): /html/body
-      Text size too small (10px): /html/body/span[1]
-      Text size too small (10px): /html/body/span[2]
       Text size too small (9px): /html/body/span[2]/b
       """
 

--- a/lib/standards/minimumTextSize/textCannotBeTooSmall.js
+++ b/lib/standards/minimumTextSize/textCannotBeTooSmall.js
@@ -16,10 +16,14 @@ module.exports = {
 
     for (var i = 0; i < parents.length; ++i) {
       var element = $(parents[i]);
-      var size = parseInt(element.css('fontSize').replace('px', ''), 10);
-      if (size < 11) {
+      var size = fontSizeOf(element);
+      if (size < 11 && size != fontSizeOf(element.parent())) {
         fail('Text size too small (' + size + 'px):', element);
       }
     }
   }
+}
+
+function fontSizeOf(element) {
+  return Number(element.css('fontSize').replace('px', ''));
 }


### PR DESCRIPTION
When a parent and child element have the same font size, which is too small, only report the parent