### PR TITLE
Delete x-frame-options header (case insensitive)

### DIFF
--- a/electron/bbc-a11y.js
+++ b/electron/bbc-a11y.js
@@ -35,8 +35,10 @@ function createWindow () {
   })
 
   mainWindow.webContents.session.webRequest.onHeadersReceived({}, function (d, c) {
-    if(d.responseHeaders['X-Frame-Options']){
-      delete d.responseHeaders['X-Frame-Options'];
+    for (var header in d.responseHeaders) {
+      if (header.toLowerCase() == 'x-frame-options') {
+        delete d.responseHeaders[header]
+      }
     }
     c({ cancel: false, responseHeaders: d.responseHeaders })
   })

--- a/features/ignore_x_frame_options.feature
+++ b/features/ignore_x_frame_options.feature
@@ -1,0 +1,6 @@
+Feature: Ignore x-frame-options header
+
+  Scenario: Page sets x-frame-options=SAMEORIGIN
+    Given a website running at http://localhost:54321
+    When I run `bbc-a11y http://localhost:54321/x-frame-options.html`
+    Then it passes

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -97,10 +97,14 @@ defineSupportCode(function({ Given, When, Then }) {
   })
 
   Then('it passes', function () {
-    var pass = !this.validationResult.results.find(function(result) {
-      return result.errors.length > 0
-    })
-    assert(pass)
+    if ('exitCode' in this) {
+      assert.equal(this.exitCode, 0, "\n" + this.stdout + this.stderr)
+    } else {
+      var pass = !this.validationResult.results.find(function(result) {
+        return result.errors.length > 0
+      })
+      assert(pass)
+    }
   })
 
   Then('it should fail with:', function (expectedOutput) {

--- a/features/support/web_server.js
+++ b/features/support/web_server.js
@@ -13,6 +13,9 @@ module.exports = {
       good = !good
       res.set('Cache-Control', 'max-age=86400').status(200).end(fs.readFileSync(__dirname + '/web_server/' + page))
     })
+    app.get('/x-frame-options.html', (req, res) => {
+      res.set('x-frame-options', 'SAMEORIGIN').status(200).end(fs.readFileSync(__dirname + '/web_server/perfect.html'))
+    })
     app.use(express.static(__dirname + '/web_server'))
     return new Promise(function(resolve, reject) {
       var listener = app.listen(port, function(err) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "./node_modules/.bin/electron-mocha --renderer && ./node_modules/.bin/cucumber-electron",
     "browserify": "browserify ./lib/a11y.js -o ./dist/bundle.js",
-    "watchify": "watchify ./lib/a11y.js -o ./dist/bundle.js"
+    "watchify": "watchify ./lib/a11y.js -o ./dist/bundle.js",
+    "web-server": "node -e \"require('./features/support/web_server').ensureRunningOn(7654).then(() => console.log('http://localhost:7654'))\""
   },
   "bin": {
     "bbc-a11y": "./bin/bbc-a11y.js"


### PR DESCRIPTION
Fixes an issue where certain web pages were inaccessible by bbc-a11y, if a particular response header was present