### PR TITLE
Junit Reporter

### DIFF
--- a/features/cli/command_line_help.feature
+++ b/features/cli/command_line_help.feature
@@ -13,5 +13,5 @@ Feature: Command Line Help
         -i, --interactive          show browser window and leave open for debugging
         -w, --width <pixels>       override viewport width
         -c, --config <config>      path to config file
-        -r, --reporter <reporter>  json or [path to custom reporter module]
+        -r, --reporter <reporter>  json or junit or [path to custom reporter module]
     """

--- a/features/cli/junit_reporter.feature
+++ b/features/cli/junit_reporter.feature
@@ -1,0 +1,52 @@
+Feature: JUnit Reporter
+  Scenario: Reporting results in JUnit format
+    Given a website running at http://localhost:54321
+    And a file named "a11y.js" with:
+      """
+      page("http://localhost:54321/perfect.html")
+      page("http://localhost:54321/missing_main_heading.html")
+      """
+    When I run `bbc-a11y --reporter junit`
+    Then it should fail with exactly:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites>
+        <testsuite name="bbc-a11y" tests="15" failures="0" errors="0" skipped="0">
+          <testcase classname="http://localhost:54321/perfect.html" name="Focusable controls: Anchors must have hrefs -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/focusable-controls.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Form interactions: Forms must have submit buttons -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/form-interaction.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Form labels: Fields must have labels or titles -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/form-labels.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Headings: Content must follow headings -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/headings.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Headings: Exactly one main heading -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/headings.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Headings: Headings must be in ascending order -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/headings.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Image alternatives: Images must have alt attributes -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/image-alt.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Indicating language: Html must have lang attribute -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/language.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Main landmark: Exactly one Main landmark -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/main-landmark.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Minimum text size: Text cannot be too small -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/min-text-size.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Tab index: Zero Tab index must only be set on elements which are focusable by default -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tabindex.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Tables: Use tables for data -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tables.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Title attributes: Title attributes must not duplicate content -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/title-attributes.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Title attributes: Title attributes only on inputs -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/title-attributes.shtml"/>
+          <testcase classname="http://localhost:54321/perfect.html" name="Visible on focus: Elements must be visible on focus -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/visible-on-focus.shtml"/>
+        </testsuite>
+        <testsuite name="bbc-a11y" tests="15" failures="1" errors="0" skipped="0">
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Focusable controls: Anchors must have hrefs -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/focusable-controls.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Form interactions: Forms must have submit buttons -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/form-interaction.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Form labels: Fields must have labels or titles -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/form-labels.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Headings: Content must follow headings -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/headings.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Headings: Exactly one main heading -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/headings.shtml">
+            <failure message="Found 0 h1 elements."/>
+          </testcase>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Headings: Headings must be in ascending order -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/headings.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Image alternatives: Images must have alt attributes -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/image-alt.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Indicating language: Html must have lang attribute -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/language.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Main landmark: Exactly one Main landmark -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/main-landmark.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Minimum text size: Text cannot be too small -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/min-text-size.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Tab index: Zero Tab index must only be set on elements which are focusable by default -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tabindex.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Tables: Use tables for data -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/tables.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Title attributes: Title attributes must not duplicate content -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/title-attributes.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Title attributes: Title attributes only on inputs -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/title-attributes.shtml"/>
+          <testcase classname="http://localhost:54321/missing_main_heading.html" name="Visible on focus: Elements must be visible on focus -- http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/visible-on-focus.shtml"/>
+        </testsuite>
+      </testsuites>
+
+      """

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -151,9 +151,13 @@ Override the human-readable output format with JSON instead like this:
 
 ## Output results in JUnit format
 
-Override the human-readable output format with a JUNit report (test-report.xml) instead like this:
+Override the human-readable output format with a JUNit report instead like this:
 
     ./node_modules/.bin/bbc-a11y --reporter junit
+
+You'll probably want to redirect the output to a file, e.g:
+
+    ./node_modules/.bin/bbc-a11y --reporter junit > bbc-a11y-junit-results.xml
 
 ## Using a custom reporter
 

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -149,6 +149,12 @@ Override the human-readable output format with JSON instead like this:
 
     ./node_modules/.bin/bbc-a11y --reporter json
 
+## Output results in JUnit format
+
+Override the human-readable output format with a JUNit report (test-report.xml) instead like this:
+
+    ./node_modules/.bin/bbc-a11y --reporter junit
+
 ## Using a custom reporter
 
 If your CI system renders reports in different format, you can write your own

--- a/lib/commandLineArgs.js
+++ b/lib/commandLineArgs.js
@@ -9,7 +9,7 @@ var commandLineArgs = {
       .option('-i, --interactive', 'show browser window and leave open for debugging')
       .option('-w, --width <pixels>', 'override viewport width', parseInt)
       .option('-c, --config <config>', 'path to config file')
-      .option('-r, --reporter <reporter>', 'json or [path to custom reporter module]')
+      .option('-r, --reporter <reporter>', 'json or junit or [path to custom reporter module]')
       .parse(argv)
 
     return {

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -7,27 +7,20 @@ function JUnitReport(devToolsConsole, commandLineConsole) {
 }
 
 JUnitReport.prototype.runStarted = function() {
-  this.log('Running tests...')
 }
 
 JUnitReport.prototype.pageChecked = function(page, validationResult) {
-  var suiteName = page.url;
-  suiteName = suiteName.replace(/.*?:\/\//g, "").replace('\/', './');
-  var suite = builder.testSuite().name(suiteName)
+  var suite = builder.testSuite().name('bbc-a11y')
 
   validationResult.results.forEach(function(standardResult) {
     var standard = standardResult.standard
     var testName = standard.section.title + ': ' + standard.name
     var docsUrl = standard.section.documentationUrl
-    var testcase = suite.testCase().className(suiteName).name(testName)
-
-    if (standardResult.errors.length > 0) {
-      var errors = standardResult.errors.map(mapErrors)
-      testcase.failure('Error on [ ' + page.url + ' ]: ' + errors.join('') + 'More info at ' + docsUrl)
-    }
+    var testcase = suite.testCase().className(page.url).name(testName + ' -- ' + docsUrl)
+    standardResult.errors.forEach(function (error) {
+      testcase.failure(error.map(function(part) { return part.xpath ? part.xpath : part.toString() } ).join(' '))
+    })
   })
-
-  this.log('Checked ' + page.url)
 }
 
 JUnitReport.prototype.pagePassed = function(page, validationResult) {}
@@ -35,8 +28,7 @@ JUnitReport.prototype.pagePassed = function(page, validationResult) {}
 JUnitReport.prototype.pageFailed = function(page, validationResult) {}
 
 JUnitReport.prototype.runEnded = function() {
-  builder.writeTo(reportFileName)
-  this.log('Report written to ' + reportFileName)
+  this.log(builder.build())
 }
 
 JUnitReport.prototype.unexpectedError = function(error) {
@@ -53,13 +45,6 @@ JUnitReport.prototype.configError = function(error) {
 
 JUnitReport.prototype.log = function(message) {
   this.commandLineConsole.log(message)
-}
-
-JUnitReport.prototype.alwaysExitWithSuccess = true
-
-function mapErrors(error) {
-  var errorDetails = (error[1] && error[1].xpath) || ''
-  return error[0] + ' ' + errorDetails + '             '
 }
 
 module.exports = JUnitReport

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -1,0 +1,65 @@
+var builder = require('junit-report-builder')
+var reportFileName = 'test-report.xml'
+
+function JUnitReport(devToolsConsole, commandLineConsole) {
+  this.devToolsConsole = devToolsConsole
+  this.commandLineConsole = commandLineConsole
+}
+
+JUnitReport.prototype.runStarted = function() {
+  this.log('Running tests...')
+}
+
+JUnitReport.prototype.pageChecked = function(page, validationResult) {
+  var suiteName = page.url;
+  suiteName = suiteName.replace(/.*?:\/\//g, "").replace('\/', './');
+  var suite = builder.testSuite().name(suiteName)
+
+  validationResult.results.forEach(function(standardResult) {
+    var standard = standardResult.standard
+    var testName = standard.section.title + ': ' + standard.name
+    var docsUrl = standard.section.documentationUrl
+    var testcase = suite.testCase().className(suiteName).name(testName)
+
+    if (standardResult.errors.length > 0) {
+      var errors = standardResult.errors.map(mapErrors)
+      testcase.failure('Error on [ ' + page.url + ' ]: ' + errors.join('') + 'More info at ' + docsUrl)
+    }
+  })
+
+  this.log('Checked ' + page.url)
+}
+
+JUnitReport.prototype.pagePassed = function(page, validationResult) {}
+
+JUnitReport.prototype.pageFailed = function(page, validationResult) {}
+
+JUnitReport.prototype.runEnded = function() {
+  builder.writeTo(reportFileName)
+  this.log('Report written to ' + reportFileName)
+}
+
+JUnitReport.prototype.unexpectedError = function(error) {
+  this.log('Error running tests: ' + error.stack)
+}
+
+JUnitReport.prototype.configMissing = function(error) {
+  this.log('Error running tests: Missing configuration file')
+}
+
+JUnitReport.prototype.configError = function(error) {
+  this.log('Error running tests: ' + error.stack)
+}
+
+JUnitReport.prototype.log = function(message) {
+  this.commandLineConsole.log(message)
+}
+
+JUnitReport.prototype.alwaysExitWithSuccess = true
+
+function mapErrors(error) {
+  var errorDetails = (error[1] && error[1].xpath) || ''
+  return error[0] + ' ' + errorDetails + '             '
+}
+
+module.exports = JUnitReport

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "commander": "^2.9.0",
     "electron": "1.4.14",
-    "jquery": "3.1.1"
+    "jquery": "3.1.1",
+    "junit-report-builder": "^1.1.1"
   },
   "devDependencies": {
     "browserify": "13.3.0",


### PR DESCRIPTION
Hey @andymsuk, I built on top of your branch and made a few changes for consistency with the JSON formatter:

* The junit reporter writes to stdout, not to a file
* The `<testcase />` class names map back exactly to page URLs
* `<testcase />` can have multiple failures, one for each validation error (this is probably the most contentious change
* The documentation links are embedded in each test case, not in each error

Can you let me know if this works for you?