### PR TITLE
Semi-automated title test

### DIFF
--- a/features/check_standards/05_page_titles.feature
+++ b/features/check_standards/05_page_titles.feature
@@ -10,7 +10,29 @@ Feature: Page Titles
   user will hear and acts as a confirmation of what page they have arrived at.
   Document titles commonly have the same content as the main <h1> element.
 
-  Scenario: Valid page title
+  Scenario: Valid page title with template string
+    Given a page with the HTML:
+      """
+      <!DOCTYPE html>
+      <html lang="en-GB">
+        <head>
+          <title>Chocolate brownies - Yummy recipe site</title>
+        </head>
+        <body>
+          <h1>Chocolate brownies</h1>
+        </body>
+      </html>
+      """
+    When my page configuration is:
+      """
+      {
+        pageTitleFormat: '{h1:first} - Yummy recipe site'
+      }
+      """
+    When I validate the "Page titles: Title element must identify main content" standard
+    Then it passes
+
+  Scenario: Valid page title with template function
     Given a page with the HTML:
       """
       <!DOCTYPE html>
@@ -31,6 +53,31 @@ Feature: Page Titles
       """
     When I validate the "Page titles: Title element must identify main content" standard
     Then it passes
+
+  Scenario: Valid page title with invalid template
+    Given a page with the HTML:
+      """
+      <!DOCTYPE html>
+      <html lang="en-GB">
+        <head>
+          <title>Chocolate brownies - Yummy recipe site</title>
+        </head>
+        <body>
+          <h1>Chocolate brownies</h1>
+        </body>
+      </html>
+      """
+    When my page configuration is:
+      """
+      {
+        pageTitleFormat: 666
+      }
+      """
+    When I validate the "Page titles: Title element must identify main content" standard
+    Then it fails with the message:
+      """
+      Invalid pageTitleFormat 666
+      """
 
   Scenario: Invalid page title
     Given a page with the HTML:

--- a/features/check_standards/05_page_titles.feature
+++ b/features/check_standards/05_page_titles.feature
@@ -10,6 +10,28 @@ Feature: Page Titles
   user will hear and acts as a confirmation of what page they have arrived at.
   Document titles commonly have the same content as the main <h1> element.
 
+  Scenario: Valid page title with string
+    Given a page with the HTML:
+      """
+      <!DOCTYPE html>
+      <html lang="en-GB">
+        <head>
+          <title>Chocolate brownies - Yummy recipe site</title>
+        </head>
+        <body>
+          <h1>Chocolate brownies</h1>
+        </body>
+      </html>
+      """
+    When my page configuration is:
+      """
+      {
+        title: 'Chocolate brownies - Yummy recipe site'
+      }
+      """
+    When I validate the "Page titles: Title element must identify main content" standard
+    Then it passes
+
   Scenario: Valid page title with template string
     Given a page with the HTML:
       """
@@ -26,7 +48,7 @@ Feature: Page Titles
     When my page configuration is:
       """
       {
-        pageTitleFormat: '{h1:first} - Yummy recipe site'
+        title: '{h1:first} - Yummy recipe site'
       }
       """
     When I validate the "Page titles: Title element must identify main content" standard
@@ -48,7 +70,7 @@ Feature: Page Titles
     When my page configuration is:
       """
       {
-        pageTitleFormat: $ => $('h1').text() + ' - Yummy recipe site'
+        title: $ => $('h1').text() + ' - Yummy recipe site'
       }
       """
     When I validate the "Page titles: Title element must identify main content" standard
@@ -70,13 +92,13 @@ Feature: Page Titles
     When my page configuration is:
       """
       {
-        pageTitleFormat: 666
+        title: 666
       }
       """
     When I validate the "Page titles: Title element must identify main content" standard
     Then it fails with the message:
       """
-      Invalid pageTitleFormat 666
+      Invalid title 666
       """
 
   Scenario: Invalid page title
@@ -95,7 +117,7 @@ Feature: Page Titles
     When my page configuration is:
       """
       {
-        pageTitleFormat: $ => $('h1').text() + ' - Yummy recipe site'
+        title: $ => $('h1').text() + ' - Yummy recipe site'
       }
       """
     When I validate the "Page titles: Title element must identify main content" standard

--- a/features/check_standards/05_page_titles.feature
+++ b/features/check_standards/05_page_titles.feature
@@ -1,1 +1,58 @@
 Feature: Page Titles
+
+  Documents must have a page <title> that identifies its main content.
+
+  Rationale
+  =========
+
+  Document titles help users orientate themselves within web sites and apps.
+  The document <title> element content is often the first thing a speech output
+  user will hear and acts as a confirmation of what page they have arrived at.
+  Document titles commonly have the same content as the main <h1> element.
+
+  Scenario: Valid page title
+    Given a page with the HTML:
+      """
+      <!DOCTYPE html>
+      <html lang="en-GB">
+        <head>
+          <title>Chocolate brownies - Yummy recipe site</title>
+        </head>
+        <body>
+          <h1>Chocolate brownies</h1>
+        </body>
+      </html>
+      """
+    When my page configuration is:
+      """
+      {
+        pageTitleFormat: $ => $('h1').text() + ' - Yummy recipe site'
+      }
+      """
+    When I validate the "Page titles: Title element must identify main content" standard
+    Then it passes
+
+  Scenario: Invalid page title
+    Given a page with the HTML:
+      """
+      <!DOCTYPE html>
+      <html lang="en-GB">
+        <head>
+          <title>Oops wrong title - Yummy recipe site</title>
+        </head>
+        <body>
+          <h1>Sausage rolls</h1>
+        </body>
+      </html>
+      """
+    When my page configuration is:
+      """
+      {
+        pageTitleFormat: $ => $('h1').text() + ' - Yummy recipe site'
+      }
+      """
+    When I validate the "Page titles: Title element must identify main content" standard
+    Then it fails with the message:
+      """
+      Title element failed to identify main content: expected "Sausage rolls - Yummy recipe site", actual "Oops wrong title - Yummy recipe site"
+      """

--- a/features/cli/json_reporter.feature
+++ b/features/cli/json_reporter.feature
@@ -104,6 +104,15 @@ Feature: JSON Reporter
                 },
                 {
                   "standard": {
+                    "section": "Page titles",
+                    "name": "Title element must identify main content"
+                  },
+                  "errors": [],
+                  "warnings": [],
+                  "hiddenErrors": []
+                },
+                {
+                  "standard": {
                     "section": "Tab index",
                     "name": "Zero Tab index must only be set on elements which are focusable by default"
                   },
@@ -250,6 +259,15 @@ Feature: JSON Reporter
                   "standard": {
                     "section": "Minimum text size",
                     "name": "Text cannot be too small"
+                  },
+                  "errors": [],
+                  "warnings": [],
+                  "hiddenErrors": []
+                },
+                {
+                  "standard": {
+                    "section": "Page titles",
+                    "name": "Title element must identify main content"
                   },
                   "errors": [],
                   "warnings": [],

--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -89,11 +89,15 @@ defineSupportCode(function({ Given, When, Then }) {
     })
   })
 
+  When('my page configuration is:', function (string) {
+    eval(`this.pageConfiguration = ${string}`)
+  })
+
   When('I validate the {name:stringInDoubleQuotes} standard', function (name) {
     var $ = jquery(this.pageFrame.contentDocument)
     var matching = Standards.matching(name)
     if (matching.standards.length != 1) throw new Error("Expected 1 standard called '" + name + "', found " + matching.standards.length)
-    this.validationResult = matching.validate($.find.bind($))
+    this.validationResult = matching.validate($.find.bind($), this.pageConfiguration || {})
   })
 
   Then('it passes', function () {

--- a/guides/using/semi-automated-tests.md
+++ b/guides/using/semi-automated-tests.md
@@ -6,12 +6,29 @@ them. The following tests are semi-automated:
 
 ### Page titles
 
-The `pageTitleFormat` page configuration setting is set to a function which
-should return the inner text of the `<title>` element. Usually this should
-correspond to the main heading on the page, for example:
+The `title` page configuration setting should be set to one of:
 
-```
-page("http://www.bbc.co.uk/news/business-39383896", {
-  pageTitleFormat: $ => $('h1').text() + ' - BBC News'
+  * a string with the exact title
+  * a string with a template part containing a CSS selector, for example
+    `Site Name - {h1:first}`
+  * a function taking a jQuery object as an argument and returning the title
+
+This setting will be matched against should the inner text of the `<title>`
+element, for example each of these tests will pass:
+
+```js
+// Given the HTML at http://www.bbc.co.uk/news/technology-39419728 includes:
+// <title>Uber set to pull out of Denmark - BBC News</title>
+
+page('http://www.bbc.co.uk/news/technology-39419728', {
+  title: 'Uber set to pull out of Denmark - BBC News'
+})
+
+page('http://www.bbc.co.uk/news/technology-39419728', {
+  title: '{h1:first} - BBC News'
+})
+
+page('http://www.bbc.co.uk/news/technology-39419728', {
+  title: $ => $('h1:first').text() + ' - BBC News'
 })
 ```

--- a/guides/using/semi-automated-tests.md
+++ b/guides/using/semi-automated-tests.md
@@ -1,0 +1,17 @@
+# Semi-automated tests
+
+Some standards need additional configuration before they are run. These are
+considered optional, so they will not generate warnings if you don't configure
+them. The following tests are semi-automated:
+
+### Page titles
+
+The `pageTitleFormat` page configuration setting is set to a function which
+should return the inner text of the `<title>` element. Usually this should
+correspond to the main heading on the page, for example:
+
+```
+page("http://www.bbc.co.uk/news/business-39383896", {
+  pageTitleFormat: $ => $('h1').text() + ' - BBC News'
+})
+```

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -133,8 +133,9 @@ configuration file, for example:
 
 ## Semi-automated tests
 
-Some tests cannot be fully automated. These [semi-automated tests] need
-additional page configuration to be executed by bbc-a11y. 
+Some tests cannot be fully automated. These
+[semi-automated tests](./semi-automated-tests.md) need additional page
+configuration before they can be executed by bbc-a11y. 
 
 ## Specifying a configuration file path
 

--- a/guides/using/validating-your-project.md
+++ b/guides/using/validating-your-project.md
@@ -131,6 +131,11 @@ configuration file, for example:
 [800, 1000].forEach(width => page("http://bbc.co.uk", { width }))
 ```
 
+## Semi-automated tests
+
+Some tests cannot be fully automated. These [semi-automated tests] need
+additional page configuration to be executed by bbc-a11y. 
+
 ## Specifying a configuration file path
 
 Use the `--config` command line option to specify an alternative location for

--- a/lib/a11y.js
+++ b/lib/a11y.js
@@ -2,8 +2,8 @@ var jquery = require('jquery');
 var standards = require('./standards');
 
 window.a11y = {
-  validate: function(pattern, finder) {
-    return standards.matching(pattern).validate(finder || jquery);
+  validate: function(pageConfiguration, finder) {
+    return standards.matching(pageConfiguration).validate(finder || jquery, pageConfiguration || {});
   }
 };
 

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -74,7 +74,7 @@ Standards.sections = {
     documentationUrl: 'http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/min-text-size.shtml'
   },
 
-  pageTitles: {
+  titles: {
     title: 'Page titles',
     tests: [
       require('./pageTitles/titleElementMustIdentifyMainContent')

--- a/lib/standards/index.js
+++ b/lib/standards/index.js
@@ -74,6 +74,14 @@ Standards.sections = {
     documentationUrl: 'http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/min-text-size.shtml'
   },
 
+  pageTitles: {
+    title: 'Page titles',
+    tests: [
+      require('./pageTitles/titleElementMustIdentifyMainContent')
+    ],
+    documentationUrl: 'http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/page-titles.shtml'
+  },
+
   tabIndex: {
     title: 'Tab index',
     tests: [
@@ -119,7 +127,7 @@ for (var section in Standards.sections) {
   }
 }
 
-Standards.prototype.validate = function(jquery) {
+Standards.prototype.validate = function(jquery, pageConfiguration) {
   var pageResult = new PageResult(this.skipped, this.hide)
   var standardResult;
   function fail() {
@@ -132,7 +140,7 @@ Standards.prototype.validate = function(jquery) {
     standard = this.standards[i];
     standardResult = pageResult.createStandardResult(this.standards[i].section, this.standards[i].name);
 
-    standard.validate(jquery, fail, warn);
+    standard.validate(jquery, fail, warn, pageConfiguration);
 
     function validateFrames(framePath, $) {
       var frames = $('iframe')
@@ -147,7 +155,7 @@ Standards.prototype.validate = function(jquery) {
           var args = ['In frame', thisFramePath, ':'].concat([].slice.apply(arguments))
           warn.apply(null, args)
         }
-        standard.validate(findInFrame, failInFrame, warnInFrame)
+        standard.validate(findInFrame, failInFrame, warnInFrame, pageConfiguration)
         validateFrames(thisFramePath, findInFrame)
       }
     }

--- a/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
+++ b/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
@@ -1,0 +1,14 @@
+module.exports = {
+  name: 'Title element must identify main content',
+
+  validate: function($, fail, warn, pageConfiguration) {
+    if (typeof pageConfiguration.pageTitleFormat == 'function') {
+      var actualTitle = $('title').text()
+      var expectedTitle = pageConfiguration.pageTitleFormat($)
+      if (expectedTitle != actualTitle) {
+        fail('Title element failed to identify main content: ' +
+             'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
+      }
+    }
+  }
+}

--- a/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
+++ b/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
@@ -9,6 +9,20 @@ module.exports = {
         fail('Title element failed to identify main content: ' +
              'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
       }
+    } else if (typeof pageConfiguration.pageTitleFormat === 'string') {
+      var actualTitle = $('title').text()
+      var expectedTitle = pageConfiguration.pageTitleFormat
+      var templatePart = expectedTitle.match(/\{([^}].+)\}/)
+      if (templatePart) {
+        var templatePartText = $(templatePart[1]).text()
+        expectedTitle = expectedTitle.replace(templatePart[0], templatePartText)
+      }
+      if (expectedTitle != actualTitle) {
+        fail('Title element failed to identify main content: ' +
+             'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
+      }
+    } else {
+      fail('Invalid pageTitleFormat ' + pageConfiguration.pageTitleFormat.toString())
     }
   }
 }

--- a/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
+++ b/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
@@ -2,27 +2,27 @@ module.exports = {
   name: 'Title element must identify main content',
 
   validate: function($, fail, warn, pageConfiguration) {
-    if (typeof pageConfiguration.title == 'function') {
-      var actualTitle = $('title').text()
-      var expectedTitle = pageConfiguration.title($)
-      if (expectedTitle != actualTitle) {
+    function testTitle(expected) {
+      var actual = $('title').text()
+      if (expected != actual) {
         fail('Title element failed to identify main content: ' +
-             'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
+             'expected "' + expected + '", actual "' + actual + '"')
       }
-    } else if (typeof pageConfiguration.title === 'string') {
-      var actualTitle = $('title').text()
-      var expectedTitle = pageConfiguration.title
-      var templatePart = expectedTitle.match(/\{([^}].+)\}/)
-      if (templatePart) {
-        var templatePartText = $(templatePart[1]).text()
-        expectedTitle = expectedTitle.replace(templatePart[0], templatePartText)
-      }
-      if (expectedTitle != actualTitle) {
-        fail('Title element failed to identify main content: ' +
-             'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
-      }
-    } else if (typeof pageConfiguration.title !== 'undefined') {
-      fail('Invalid title ' + pageConfiguration.title.toString())
     }
+    var expectedTitle
+    switch (typeof pageConfiguration.title) {
+      case 'undefined':
+        return
+      case 'function':
+        return testTitle(pageConfiguration.title($))
+      case 'string':
+        var expected = pageConfiguration.title
+        var template = expected.match(/\{([^}].+)\}/)
+        if (template) {
+          expected = expected.replace(template[0], $(template[1]).text())
+        }
+        return testTitle(expected)
+    }
+    fail('Invalid title ' + pageConfiguration.title.toString())
   }
 }

--- a/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
+++ b/lib/standards/pageTitles/titleElementMustIdentifyMainContent.js
@@ -2,16 +2,16 @@ module.exports = {
   name: 'Title element must identify main content',
 
   validate: function($, fail, warn, pageConfiguration) {
-    if (typeof pageConfiguration.pageTitleFormat == 'function') {
+    if (typeof pageConfiguration.title == 'function') {
       var actualTitle = $('title').text()
-      var expectedTitle = pageConfiguration.pageTitleFormat($)
+      var expectedTitle = pageConfiguration.title($)
       if (expectedTitle != actualTitle) {
         fail('Title element failed to identify main content: ' +
              'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
       }
-    } else if (typeof pageConfiguration.pageTitleFormat === 'string') {
+    } else if (typeof pageConfiguration.title === 'string') {
       var actualTitle = $('title').text()
-      var expectedTitle = pageConfiguration.pageTitleFormat
+      var expectedTitle = pageConfiguration.title
       var templatePart = expectedTitle.match(/\{([^}].+)\}/)
       if (templatePart) {
         var templatePartText = $(templatePart[1]).text()
@@ -21,8 +21,8 @@ module.exports = {
         fail('Title element failed to identify main content: ' +
              'expected "' + expectedTitle + '", actual "' + actualTitle + '"')
       }
-    } else {
-      fail('Invalid pageTitleFormat ' + pageConfiguration.pageTitleFormat.toString())
+    } else if (typeof pageConfiguration.title !== 'undefined') {
+      fail('Invalid title ' + pageConfiguration.title.toString())
     }
   }
 }

--- a/test/runnerSpec.js
+++ b/test/runnerSpec.js
@@ -69,7 +69,6 @@ describe('Runner', function() {
   context('with no arguments', function() {
     it('loads the config file', function() {
       const configPath = path.join(__dirname, 'runnerSpec', 'a11y.js')
-      debugger
       return run([], configPath)
         .then(function(events) {
           assert.deepEqual(events[0], { type: 'loadPage', page: { url: 'http://www.bbc.co.uk/sport' } })

--- a/test/runnerSpec.js
+++ b/test/runnerSpec.js
@@ -30,6 +30,9 @@ describe('Runner', function() {
       },
       error: function() {
         events.push({ type: 'devToolsConsole.error', args: [].slice.apply(arguments) })
+      },
+      warn: function() {
+        events.push({ type: 'devToolsConsole.warn', args: [].slice.apply(arguments) })
       }
     }
     var commandLineConsole = {
@@ -38,6 +41,9 @@ describe('Runner', function() {
       },
       error: function() {
         events.push({ type: 'commandLineConsole.error', args: [].slice.apply(arguments) })
+      },
+      warn: function() {
+        events.push({ type: 'commandLineConsole.warn', args: [].slice.apply(arguments) })
       }
     }
     function exit() {
@@ -63,6 +69,7 @@ describe('Runner', function() {
   context('with no arguments', function() {
     it('loads the config file', function() {
       const configPath = path.join(__dirname, 'runnerSpec', 'a11y.js')
+      debugger
       return run([], configPath)
         .then(function(events) {
           assert.deepEqual(events[0], { type: 'loadPage', page: { url: 'http://www.bbc.co.uk/sport' } })


### PR DESCRIPTION
The first example of a "semi-automated test" which needs some user-supplied configuration before it can be executed.

I decided to express this configuration as a JavaScript function, to keep it as general as possible. This may be over-engineered. What do you think?

Can you think of examples where the text of the first `<h1>` tag is _not_ included in the `<title>`? 