### PR TITLE
Refactoring: introduce window adapter

### DIFF
--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -4,6 +4,8 @@
  }
 
  PrettyReporter.prototype.runStarted = function () {
+   this.devToolsConsole.clear()
+   this.devToolsConsole.log('BBC a11y is testing the page...')
    this.summary = {
      pagesChecked: 0,
      errorsFound: 0,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,4 +1,5 @@
 var a11y = require('./a11y')
+var jquery = require('jquery')
 
 var configLoader = require('./configLoader')
 
@@ -6,7 +7,61 @@ function Runner (configPath) {
   this.configPath = configPath
 }
 
-function run (config, loadPage, reporter, exit) {
+function run (config, windowAdapter, reporter, exit) {
+  function loadPage (page) {
+    const { width, height } = windowAdapter.getContentSize()
+    const newWidth = page.width || 1024
+    const isResized = width !== newWidth
+    if (isResized) {
+      windowAdapter.setContentSize(newWidth, height)
+    }
+
+    var mainFrame = document.getElementById('mainFrame')
+
+    var promise = Promise.resolve()
+
+    if (page.visit) {
+      promise = promise.then(function () {
+        return page.visit(mainFrame)
+      })
+    }
+
+    return promise.then(function () {
+      return new Promise(function (resolve, reject) {
+        function testFrame () {
+          resolve(jquery(mainFrame).contents())
+        }
+
+        function loadUrl () {
+          if (page.visit) {
+            testFrame()
+          } else {
+            mainFrame.onload = function () {
+              testFrame()
+            }
+            mainFrame.src = page.url
+          }
+        }
+
+        function waitForResize () {
+          setTimeout(function () {
+            if (windowAdapter.measureInnerWidth() === newWidth) {
+              loadUrl()
+            } else {
+              waitForResize()
+            }
+          }, 10)
+        }
+
+        if (isResized) {
+          waitForResize()
+        } else {
+          loadUrl()
+        }
+      })
+    })
+  }
+
   var pages = config.pages
   var exitCode = 0
   reporter.runStarted()

--- a/test/runnerSpec/a11y.js
+++ b/test/runnerSpec/a11y.js
@@ -1,2 +1,3 @@
 /* global page */
-page('http://www.bbc.co.uk/sport')
+page('http://what/evs')
+page('http://and/another')


### PR DESCRIPTION
This change moves some behaviour out of the electron-specific part of the code, into the `Runner` which is the abstract entry point into running accessibility tests. It does so by introducing a `WindowAdapter` abstraction which knows how to measure and resize the window (which is necessary for changing the window width in page configurations, for example).

This makes more of the a11y code portable to other window environments (e.g. chrome headless if we decide to go that way) but most importantly, allows us to easily automate high level scenarios that involve more complex window manipulation, like the forthcoming manual testing support.