### PR TITLE
Upgrade cucumber-js to 3.0.3

### DIFF
--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -1,206 +1,204 @@
 /* eslint no-eval: "off" */
-const { defineSupportCode } = require('cucumber')
+const { Given, When, Then } = require('cucumber')
 const assert = require('assert')
 const Standards = require('../../lib/standards')
 const jquery = require('jquery')
 const webServer = require('../support/web_server')
 
-defineSupportCode(function ({ Given, When, Then }) {
-  Given('a website running at http://localhost:{int}', function (port) {
-    return webServer.ensureRunningOn(Number(port))
-  })
+Given('a website running at http://localhost:{int}', function (port) {
+  return webServer.ensureRunningOn(Number(port))
+})
 
-  Given('a file named {stringInDoubleQuotes} with:', function (filePath, contents) {
-    return this.writeFile(filePath, contents)
-  })
+Given('a file named {string} with:', function (filePath, contents) {
+  return this.writeFile(filePath, contents)
+})
 
-  Given('all the tests pass', function () {
-    return webServer.ensureRunningOn(54321)
-      .then(() => {
-        return this.runA11y('http://localhost:54321/perfect.html')
-      })
-  })
-
-  When('I run `bbc-a11y`', function () {
-    return this.runA11y()
-  })
-
-  When('I run `bbc-a11y {url}`', function (url) {
-    return this.runA11y(url)
-  })
-
-  When('I run `bbc-a11y {url} --interactive`', function (url) {
-    return this.runA11yInteractively(url)
-      .then(interactiveProcess => {
-        this.interactiveProcess = interactiveProcess
-      })
-  })
-
-  When('I run `bbc-a11y {url} --width {int}`', function (url, width) {
-    return this.runA11y(`${url} --width ${width}`)
-  })
-
-  When('I run `bbc-a11y --config {configPath}`', function (configPath) {
-    return this.runA11y(`--config ${configPath}`)
-  })
-
-  When('I run `bbc-a11y --reporter {reporter}`', function (reporter) {
-    return this.runA11y(`--reporter ${reporter}`)
-  })
-
-  When('I run `bbc-a11y --help`', function () {
-    return this.runA11y(`--help`)
-  })
-
-  When('I run `bbc-a11y {url} --manual`', function (url) {
-    return this.runA11yWithManualTests({ url })
-  })
-
-  When('I run a11y against a failing page', function () {
-    return webServer.ensureRunningOn(54321)
-      .then(() => {
-        return this.runA11y('http://localhost:54321/missing_main_heading.html')
-      })
-      .then(result => {
-        this.stdout = result.stdout
-        this.stderr = result.stderr
-        this.exitCode = result.exitCode
-      })
-  })
-
-  Given('a page with the HTML:', function (html) {
-    this.pageFrame = document.createElement('iframe')
-    document.body.appendChild(this.pageFrame)
-    return new Promise((resolve, reject) => {
-      this.pageFrame.addEventListener('load', function () {
-        resolve()
-      })
-      this.pageFrame.srcdoc = html
+Given('all the tests pass', function () {
+  return webServer.ensureRunningOn(54321)
+    .then(() => {
+      return this.runA11y('http://localhost:54321/perfect.html')
     })
-  })
+})
 
-  Given('a page with the body:', function (body) {
-    this.pageFrame = document.createElement('iframe')
-    document.body.appendChild(this.pageFrame)
-    return new Promise((resolve, reject) => {
-      this.pageFrame.addEventListener('load', function () {
-        resolve()
-      })
-      this.pageFrame.srcdoc = '<html><body>' + body + '</body></html>'
+When('I run `bbc-a11y`', function () {
+  return this.runA11y()
+})
+
+When('I run `bbc-a11y {url}`', function (url) {
+  return this.runA11y(url)
+})
+
+When('I run `bbc-a11y {url} --interactive`', function (url) {
+  return this.runA11yInteractively(url)
+    .then(interactiveProcess => {
+      this.interactiveProcess = interactiveProcess
     })
-  })
+})
 
-  When('my page configuration is:', function (string) {
-    eval(`this.pageConfiguration = ${string}`)
-  })
+When('I run `bbc-a11y {url} --width {int}`', function (url, width) {
+  return this.runA11y(`${url} --width ${width}`)
+})
 
-  When('I test the {stringInDoubleQuotes} standard', function (name) {
-    var $ = jquery(this.pageFrame.contentDocument)
-    var matching = Standards.matching(name)
-    if (matching.standards.length !== 1) throw new Error("Expected 1 standard called '" + name + "', found " + matching.standards.length)
-    return matching.test($.find.bind($), this.pageConfiguration || {})
-      .then(outcome => { this.outcome = outcome })
-  })
+When('I run `bbc-a11y --config {configPath}`', function (configPath) {
+  return this.runA11y(`--config ${configPath}`)
+})
 
-  Then('it passes', function () {
-    if ('exitCode' in this) {
-      assert.equal(this.exitCode, 0, '\n' + this.stdout + this.stderr)
-    } else {
-      var resultsWithErrors = this.outcome.results.filter(function (result) {
-        return result.errors.length > 0
-      })
-      assert(resultsWithErrors.length === 0, '\nExpected pass, but it failed with:\n' + require('util').inspect(resultsWithErrors, false, null))
-    }
-  })
+When('I run `bbc-a11y --reporter {reporter}`', function (reporter) {
+  return this.runA11y(`--reporter ${reporter}`)
+})
 
-  Then('it passes with the warning:', function (message) {
-    var pass = !this.outcome.results.find(function (result) {
+When('I run `bbc-a11y --help`', function () {
+  return this.runA11y(`--help`)
+})
+
+When('I run `bbc-a11y {url} --manual`', function (url) {
+  return this.runA11yWithManualTests({ url })
+})
+
+When('I run a11y against a failing page', function () {
+  return webServer.ensureRunningOn(54321)
+    .then(() => {
+      return this.runA11y('http://localhost:54321/missing_main_heading.html')
+    })
+    .then(result => {
+      this.stdout = result.stdout
+      this.stderr = result.stderr
+      this.exitCode = result.exitCode
+    })
+})
+
+Given('a page with the HTML:', function (html) {
+  this.pageFrame = document.createElement('iframe')
+  document.body.appendChild(this.pageFrame)
+  return new Promise((resolve, reject) => {
+    this.pageFrame.addEventListener('load', function () {
+      resolve()
+    })
+    this.pageFrame.srcdoc = html
+  })
+})
+
+Given('a page with the body:', function (body) {
+  this.pageFrame = document.createElement('iframe')
+  document.body.appendChild(this.pageFrame)
+  return new Promise((resolve, reject) => {
+    this.pageFrame.addEventListener('load', function () {
+      resolve()
+    })
+    this.pageFrame.srcdoc = '<html><body>' + body + '</body></html>'
+  })
+})
+
+When('my page configuration is:', function (string) {
+  eval(`this.pageConfiguration = ${string}`)
+})
+
+When('I test the {string} standard', function (name) {
+  var $ = jquery(this.pageFrame.contentDocument)
+  var matching = Standards.matching(name)
+  if (matching.standards.length !== 1) throw new Error("Expected 1 standard called '" + name + "', found " + matching.standards.length)
+  return matching.test($.find.bind($), this.pageConfiguration || {})
+    .then(outcome => { this.outcome = outcome })
+})
+
+Then('it passes', function () {
+  if ('exitCode' in this) {
+    assert.equal(this.exitCode, 0, '\n' + this.stdout + this.stderr)
+  } else {
+    var resultsWithErrors = this.outcome.results.filter(function (result) {
       return result.errors.length > 0
     })
-    assert(pass)
-    var actualMessage = this.outcome.results.filter(function (result) {
-      return result.warnings.length > 0
-    }).map(function (result) {
-      return result.warnings.map(function (e) {
-        return e.map(function (a) {
-          return a.xpath ? a.xpath : a
-        }).join(' ')
-      }).join('\n')
+    assert(resultsWithErrors.length === 0, '\nExpected pass, but it failed with:\n' + require('util').inspect(resultsWithErrors, false, null))
+  }
+})
+
+Then('it passes with the warning:', function (message) {
+  var pass = !this.outcome.results.find(function (result) {
+    return result.errors.length > 0
+  })
+  assert(pass)
+  var actualMessage = this.outcome.results.filter(function (result) {
+    return result.warnings.length > 0
+  }).map(function (result) {
+    return result.warnings.map(function (e) {
+      return e.map(function (a) {
+        return a.xpath ? a.xpath : a
+      }).join(' ')
     }).join('\n')
-    assert.equal(actualMessage, message)
-  })
+  }).join('\n')
+  assert.equal(actualMessage, message)
+})
 
-  Then('it should fail with:', function (expectedOutput) {
-    var actualOutput = this.stdout + this.stderr
-    expectedOutput = expectedOutput.replace('[count all standards - 1]', Standards.all.length - 1)
-    assert(actualOutput.indexOf(expectedOutput) > -1,
-      '\n------------------\nExpected:\n------------------\n' +
-      expectedOutput +
-      '\n------------------\nActual:\n------------------\n' +
-      actualOutput)
-  })
+Then('it should fail with:', function (expectedOutput) {
+  var actualOutput = this.stdout + this.stderr
+  expectedOutput = expectedOutput.replace('[count all standards - 1]', Standards.all.length - 1)
+  assert(actualOutput.indexOf(expectedOutput) > -1,
+    '\n------------------\nExpected:\n------------------\n' +
+    expectedOutput +
+    '\n------------------\nActual:\n------------------\n' +
+    actualOutput)
+})
 
-  Then('it should fail with exactly:', function (expectedOutput) {
-    var actualOutput = (this.stdout + this.stderr)
-    // HACK: work around stupid travis issue with xvfb
-    var sanitisedActualOutput = actualOutput.split('\n').filter(line => line !== 'Xlib:  extension "RANDR" missing on display ":99.0".').join('\n')
-    if (process.env.DEBUG_OUTPUT && sanitisedActualOutput !== expectedOutput) {
-      console.log(sanitisedActualOutput)
-      process.exit(1)
-    }
-    assert.equal(sanitisedActualOutput, expectedOutput, 'Expected:\n' + expectedOutput.replace(/\n/g, '[\\n]\n') + '\nActual:\n' + sanitisedActualOutput.replace(/\n/g, '[\\n]\n'))
-  })
+Then('it should fail with exactly:', function (expectedOutput) {
+  var actualOutput = (this.stdout + this.stderr)
+  // HACK: work around stupid travis issue with xvfb
+  var sanitisedActualOutput = actualOutput.split('\n').filter(line => line !== 'Xlib:  extension "RANDR" missing on display ":99.0".').join('\n')
+  if (process.env.DEBUG_OUTPUT && sanitisedActualOutput !== expectedOutput) {
+    console.log(sanitisedActualOutput)
+    process.exit(1)
+  }
+  assert.equal(sanitisedActualOutput, expectedOutput, 'Expected:\n' + expectedOutput.replace(/\n/g, '[\\n]\n') + '\nActual:\n' + sanitisedActualOutput.replace(/\n/g, '[\\n]\n'))
+})
 
-  Then('it should pass with:', function (string) {
-    var actualOutput = (this.stdout + this.stderr)
-    assert(actualOutput.indexOf(string) > -1, 'Expected:\n' + string + '\nActual:\n' + actualOutput)
-    assert.equal(this.exitCode, 0)
-  })
+Then('it should pass with:', function (string) {
+  var actualOutput = (this.stdout + this.stderr)
+  assert(actualOutput.indexOf(string) > -1, 'Expected:\n' + string + '\nActual:\n' + actualOutput)
+  assert.equal(this.exitCode, 0)
+})
 
-  Then('it fails with the message:', function (message) {
-    var actualMessage = this.outcome.results.filter(function (result) {
-      return result.errors.length > 0
-    }).map(function (err) {
-      return err.errors.map(function (e) {
-        return e.map(function (a) {
-          return a.xpath ? a.xpath : a
-        }).join(' ')
-      }).join('\n')
+Then('it fails with the message:', function (message) {
+  var actualMessage = this.outcome.results.filter(function (result) {
+    return result.errors.length > 0
+  }).map(function (err) {
+    return err.errors.map(function (e) {
+      return e.map(function (a) {
+        return a.xpath ? a.xpath : a
+      }).join(' ')
     }).join('\n')
-    assert.equal(actualMessage, message)
-  })
+  }).join('\n')
+  assert.equal(actualMessage, message)
+})
 
-  Then('the exit status should be {int}', function (status) {
-    assert.equal(this.exitCode, status)
-  })
+Then('the exit status should be {int}', function (status) {
+  assert.equal(this.exitCode, status)
+})
 
-  Then('the window should remain open', function () {
-    return new Promise((resolve, reject) => {
-      this.interactiveProcess.on('error', e => reject(e))
-      this.interactiveProcess.on('close', (code, signal) => {
-        resolve()
-      })
-      this.interactiveProcess.stdout.on('data', data => {
-        if (data.toString().indexOf('Testing shows the presence, not the absence of bugs')) {
-          setTimeout(() => reject(new Error('Failed to kill the process')), 100)
-          this.interactiveProcess.kill('SIGINT')
-        }
-      })
+Then('the window should remain open', function () {
+  return new Promise((resolve, reject) => {
+    this.interactiveProcess.on('error', e => reject(e))
+    this.interactiveProcess.on('close', (code, signal) => {
+      resolve()
+    })
+    this.interactiveProcess.stdout.on('data', data => {
+      if (data.toString().indexOf('Testing shows the presence, not the absence of bugs')) {
+        setTimeout(() => reject(new Error('Failed to kill the process')), 100)
+        this.interactiveProcess.kill('SIGINT')
+      }
     })
   })
+})
 
-  Then('I answer the following questions:', function (table) {
-    const questionsAndAnswers = table.hashes()
-    return this.answerManualTestQuestions(questionsAndAnswers)
-  })
+Then('I answer the following questions:', function (table) {
+  const questionsAndAnswers = table.hashes()
+  return this.answerManualTestQuestions(questionsAndAnswers)
+})
 
-  Then('it should result in a pass for {url}', function (url) {
-    return this.countErrorsForUrl(url)
-      .then(count => assert.equal(count, 0))
-  })
+Then('it should result in a pass for {url}', function (url) {
+  return this.countErrorsForUrl(url)
+    .then(count => assert.equal(count, 0))
+})
 
-  Then('it should result in a fail for {url}', function (url) {
-    return this.countErrorsForUrl(url)
-      .then(count => assert.notEqual(count, 0))
-  })
+Then('it should result in a fail for {url}', function (url) {
+  return this.countErrorsForUrl(url)
+    .then(count => assert.notEqual(count, 0))
 })

--- a/features/support/parameter_types.js
+++ b/features/support/parameter_types.js
@@ -1,0 +1,19 @@
+const { defineParameterType } = require('cucumber')
+
+defineParameterType({
+  name: 'url',
+  regexp: /http\S+/,
+  transformer: str => str
+})
+
+defineParameterType({
+  name: 'reporter',
+  regexp: /(json|\S+\.js)/,
+  transformer: str => str
+})
+
+defineParameterType({
+  name: 'configPath',
+  regexp: /\S+\.js/,
+  transformer: str => str
+})

--- a/features/support/transforms.js
+++ b/features/support/transforms.js
@@ -1,9 +1,0 @@
-const { defineSupportCode } = require('cucumber')
-
-defineSupportCode(function ({ addTransform }) {
-  addTransform({
-    captureGroupRegexps: ['http:\\/\\/\\S+'],
-    transformer: str => str,
-    typeName: 'url'
-  })
-})

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,4 +1,4 @@
-const { defineSupportCode } = require('cucumber')
+const { setWorldConstructor, Before, After } = require('cucumber')
 const mkdirp = require('mkdirp')
 const { exec, execFile, spawn } = require('child_process')
 const path = require('path')
@@ -103,17 +103,15 @@ function A11yWorld () {
   }
 }
 
-defineSupportCode(function ({ setWorldConstructor, Before, After }) {
-  setWorldConstructor(A11yWorld)
+setWorldConstructor(A11yWorld)
 
-  Before(function (scenario, callback) {
-    exec('rm -rf ' + this.tempDir, (err, out) => {
-      if (err) return callback(err)
-      mkdirp(this.tempDir, callback)
-    })
+Before(function (scenario, callback) {
+  exec('rm -rf ' + this.tempDir, (err, out) => {
+    if (err) return callback(err)
+    mkdirp(this.tempDir, callback)
   })
+})
 
-  After(function (scenario) {
-    if (!scenario.isFailed() && this.pageFrame) this.pageFrame.style.display = 'none'
-  })
+After(function (scenario) {
+  if (scenario.result.status === 'passed' && this.pageFrame) this.pageFrame.style.display = 'none'
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbc-a11y",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,16 @@
       "version": "7.0.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.33.tgz",
       "integrity": "sha512-8fVvl6Yyk3jZvSYxRMS9/AmZJ5RXCOP9N4xSlykyBViVESu751pxHYTN14Embn1Fem78YwEHdC7p7KGQQpwunw=="
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "accepts": {
       "version": "1.3.3",
@@ -245,7 +255,7 @@
       "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-2.0.0.tgz",
       "integrity": "sha1-F6JCicyEQIibVDGObRGH6+4tVJQ=",
       "requires": {
-        "diff": "3.3.0",
+        "diff": "3.3.1",
         "pad-right": "0.2.2",
         "repeat-string": "1.6.1"
       }
@@ -337,6 +347,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "becke-ch--regex--s0-0-v1--base--pl--lib": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/becke-ch--regex--s0-0-v1--base--pl--lib/-/becke-ch--regex--s0-0-v1--base--pl--lib-1.2.0.tgz",
+      "integrity": "sha1-LnPp0h8sLm9aVFQEVjbwq5PkYTA="
+    },
     "binary-extensions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
@@ -396,7 +411,7 @@
       "requires": {
         "array.prototype.find": "2.0.4",
         "browserify-optional": "1.0.0",
-        "chai": "4.0.2",
+        "chai": "3.5.0",
         "debug": "2.6.8",
         "detect-browser": "1.12.0",
         "finished-promise": "0.0.2",
@@ -405,6 +420,44 @@
         "jquery": "3.2.1",
         "lowscore": "1.15.0",
         "trytryagain": "1.2.0"
+      },
+      "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "1.0.2",
+            "deep-eql": "0.1.3",
+            "type-detect": "1.0.0"
+          },
+          "dependencies": {
+            "deep-eql": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+              "dev": true,
+              "requires": {
+                "type-detect": "0.1.1"
+              },
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                  "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+                  "dev": true
+                }
+              }
+            },
+            "type-detect": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+              "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "browser-pack": {
@@ -413,9 +466,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       },
@@ -497,6 +550,7 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -518,7 +572,6 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -781,17 +834,28 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
-      "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "check-error": "1.0.2",
-        "deep-eql": "2.0.2",
+        "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
         "type-detect": "4.0.3"
+      },
+      "dependencies": {
+        "deep-eql": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.3"
+          }
+        }
       }
     },
     "chalk": {
@@ -1091,9 +1155,9 @@
       }
     },
     "cucumber": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-2.3.1.tgz",
-      "integrity": "sha1-N5GlH/0MYUYq1X/bjtER1VtRzeM=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-3.0.3.tgz",
+      "integrity": "sha512-4sa3uAhnmiGWbHf7tt9/uv/vialqUCT8TsKzp8F0NVFe9eu09145C+wF6PJEFZEzp4YHeOBzkQUHOjvoLIqUpg==",
       "requires": {
         "assertion-error-formatter": "2.0.0",
         "babel-runtime": "6.23.0",
@@ -1101,9 +1165,10 @@
         "cli-table": "0.3.1",
         "colors": "1.1.2",
         "commander": "2.11.0",
-        "cucumber-expressions": "3.0.0",
+        "cucumber-expressions": "4.0.3",
         "cucumber-tag-expressions": "1.0.1",
         "duration": "0.2.0",
+        "escape-string-regexp": "1.0.5",
         "figures": "2.0.0",
         "gherkin": "4.1.3",
         "glob": "7.1.2",
@@ -1117,9 +1182,19 @@
         "stack-chain": "1.3.7",
         "stacktrace-js": "2.0.0",
         "string-argv": "0.0.2",
-        "upper-case-first": "1.1.2",
+        "title-case": "2.1.1",
         "util-arity": "1.1.0",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "cucumber-expressions": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-4.0.3.tgz",
+          "integrity": "sha512-FeSvp7/Y3QlWbOnFUq5J3389mbMZLzakQMUcYd09aV7OvfyT2nvjekNpFQ8ZcJ3w3ZkCcS05KTQS4bkLBTKVgg==",
+          "requires": {
+            "becke-ch--regex--s0-0-v1--base--pl--lib": "1.2.0"
+          }
+        }
       }
     },
     "cucumber-electron": {
@@ -1131,11 +1206,6 @@
         "ansi-to-html": "0.6.2",
         "electron-window": "0.8.1"
       }
-    },
-    "cucumber-expressions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-3.0.0.tgz",
-      "integrity": "sha1-TPQkgT2uOWzJ2rcUuBBLRZvvwyw="
     },
     "cucumber-tag-expressions": {
       "version": "1.0.1",
@@ -1190,23 +1260,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "deep-eql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
-      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
-      "dev": true,
-      "requires": {
-        "type-detect": "3.0.0"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
-          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
-          "dev": true
-        }
-      }
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -1276,12 +1329,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
-      "dev": true
     },
     "deps-sort": {
       "version": "2.0.0",
@@ -1376,9 +1423,9 @@
       }
     },
     "diff": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -1486,9 +1533,9 @@
       "dev": true
     },
     "electron": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.11.tgz",
-      "integrity": "sha1-vnnA69zv7bW/KBF0CYAPpTus7/o=",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.6.tgz",
+      "integrity": "sha1-+2nqMb0D3w7/JH8m8LU4vSm27nI=",
       "requires": {
         "@types/node": "7.0.33",
         "electron-download": "3.3.0",
@@ -1512,36 +1559,45 @@
       }
     },
     "electron-mocha": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-4.0.0.tgz",
-      "integrity": "sha512-N/A3P7S/fDu0d4TfFnOUFhNCITAT8TUJgM070RE7lQVjfyu+m9JvVgEmALFXPj7zTanmT2eKqthNrd5qxeQxbw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-4.0.2.tgz",
+      "integrity": "sha512-K4Q+Gv3in7G2UvW1KWnwyYSQj3J0ayp791YU4jfkdZxcb0odTLnkxUW9h/Hy/B9VR+M3rVFayUVAqAfMnKUzWA==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
         "electron-window": "0.8.1",
-        "fs-extra": "3.0.1",
-        "mocha": "3.4.2",
-        "which": "1.2.14"
+        "fs-extra": "4.0.2",
+        "mocha": "3.5.0",
+        "which": "1.3.0"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
-            "jsonfile": "3.0.1",
+            "jsonfile": "4.0.0",
             "universalify": "0.1.0"
           }
         },
         "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
           }
         }
       }
@@ -1852,12 +1908,6 @@
       "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
       "dev": true
     },
-    "eslint-config-standard-jsx": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.1.tgz",
-      "integrity": "sha1-zU5GPQJo4tnnB/YfQvc/WzMzxkI=",
-      "dev": true
-    },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
@@ -2093,9 +2143,9 @@
       }
     },
     "express": {
-      "version": "4.15.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
+      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
       "dev": true,
       "requires": {
         "accepts": "1.3.3",
@@ -2104,23 +2154,23 @@
         "content-type": "1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.0",
-        "finalhandler": "1.0.3",
+        "finalhandler": "1.0.6",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
-        "qs": "6.4.0",
+        "proxy-addr": "1.1.5",
+        "qs": "6.5.0",
         "range-parser": "1.2.0",
-        "send": "0.15.3",
-        "serve-static": "1.12.3",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
@@ -2128,13 +2178,109 @@
         "vary": "1.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "parseurl": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+              "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+              "dev": true
+            }
+          }
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+          "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+          "dev": true
+        },
+        "proxy-addr": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+          "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+          "dev": true,
+          "requires": {
+            "forwarded": "0.1.0",
+            "ipaddr.js": "1.4.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+          "dev": true
+        },
+        "send": {
+          "version": "0.15.4",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.8",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.0",
+            "fresh": "0.5.0",
+            "http-errors": "1.6.2",
+            "mime": "1.3.4",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.12.4",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
+          "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+          "dev": true,
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.1",
+            "send": "0.15.4"
           }
         }
       }
@@ -2246,32 +2392,6 @@
         "randomatic": "1.1.7",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
-      }
-    },
-    "finalhandler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.7",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "find-root": {
@@ -3163,14 +3283,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3179,6 +3291,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3522,18 +3642,6 @@
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
-    "http-errors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "dev": true,
-      "requires": {
-        "depd": "1.1.0",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      }
-    },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -3552,9 +3660,9 @@
       }
     },
     "httpism": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/httpism/-/httpism-3.4.2.tgz",
-      "integrity": "sha1-yCyGc7XmGgYA75Kep9ow2XEmZGU=",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/httpism/-/httpism-3.7.0.tgz",
+      "integrity": "sha512-/EPY/E6S2VVUPnQrWF3SnG8SlxWaUGiR4taJzFXipUcWLZKZqHgD3Iwm5hNXKBSPLDgxhlRwC7Hrdu2tfkJf4Q==",
       "requires": {
         "debug": "2.6.3",
         "end-of-stream": "1.4.0",
@@ -3708,10 +3816,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -3803,12 +3911,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-      "dev": true
-    },
-    "ipaddr.js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
-      "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew=",
       "dev": true
     },
     "is-arrayish": {
@@ -4133,16 +4235,6 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -4346,6 +4438,11 @@
         "signal-exit": "3.0.2"
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
     "lowscore": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/lowscore/-/lowscore-1.15.0.tgz",
@@ -4493,14 +4590,14 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
@@ -4518,15 +4615,6 @@
           "dev": true,
           "requires": {
             "graceful-readlink": "1.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
           }
         },
         "diff": {
@@ -4548,12 +4636,6 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
         }
       }
     },
@@ -4563,6 +4645,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -4570,7 +4653,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.3.3",
@@ -4696,6 +4778,14 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -5141,16 +5231,6 @@
         "through2": "0.2.3"
       }
     },
-    "proxy-addr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
-      "dev": true,
-      "requires": {
-        "forwarded": "0.1.0",
-        "ipaddr.js": "1.3.0"
-      }
-    },
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -5569,50 +5649,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
-    "send": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.1",
-        "mime": "1.3.4",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-      "dev": true,
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.3"
-      }
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -5792,20 +5828,28 @@
       }
     },
     "standard": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.2.tgz",
-      "integrity": "sha1-l0wcU8yGWwdaS1dueEQeFpXar3s=",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
         "eslint": "3.19.0",
         "eslint-config-standard": "10.2.1",
-        "eslint-config-standard-jsx": "4.0.1",
+        "eslint-config-standard-jsx": "4.0.2",
         "eslint-plugin-import": "2.2.0",
         "eslint-plugin-node": "4.2.2",
         "eslint-plugin-promise": "3.5.0",
         "eslint-plugin-react": "6.10.3",
         "eslint-plugin-standard": "3.0.1",
         "standard-engine": "7.0.0"
+      },
+      "dependencies": {
+        "eslint-config-standard-jsx": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+          "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
+          "dev": true
+        }
       }
     },
     "standard-engine": {
@@ -6011,11 +6055,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -6030,6 +6069,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6207,6 +6251,15 @@
         }
       }
     },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
+    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -6321,14 +6374,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-    },
-    "upper-case-first": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "requires": {
-        "upper-case": "1.1.3"
-      }
     },
     "url": {
       "version": "0.11.0",
@@ -6490,15 +6535,6 @@
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
-      }
-    },
-    "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/bbc/bbc-a11y#readme",
   "dependencies": {
     "commander": "2.11.0",
-    "cucumber": "3.0.1",
+    "cucumber": "3.0.3",
     "electron": "1.7.6",
     "httpism": "3.7.0",
     "jquery": "3.2.1"


### PR DESCRIPTION
Upgrading to cucumber.js 3.0.3 means:

* We lose `defineSupportCode()` when we supply callbacks to cucumber
* Transforms are renamed to parameter types
* The default output from cucumber is dots rather than verbose (pretty)