### PR TITLE
Allow arguments to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 
 RUN yarn add global bbc-a11y@mag
 
-RUN echo "#!/bin/sh\nxvfb-run node_modules/.bin/bbc-a11y %@" > /usr/local/bin/bbc-a11y
+RUN echo '#!/bin/sh\nxvfb-run node_modules/.bin/bbc-a11y "$@"' > /usr/local/bin/bbc-a11y
 RUN chmod +x /usr/local/bin/bbc-a11y
 
 ENTRYPOINT ["bbc-a11y"]


### PR DESCRIPTION
## Summary

The docker image for running bbc-a11y does not pass any command line arguments to the underlying node process

This fixes the problem such that the docker image works as documented. For example, after this change is published to dockerhub, the following command should show bbc-a11y's help message:

```
docker run bbca11y/bbc-a11y-docker --help
```