### PR TITLE
Use npm latest version in the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
     apt-get update -y && \
     apt-get install -y google-chrome-stable xvfb
 
-RUN yarn add global bbc-a11y@mag
+RUN yarn add global bbc-a11y
 
 RUN echo '#!/bin/sh\nxvfb-run node_modules/.bin/bbc-a11y "$@"' > /usr/local/bin/bbc-a11y
 RUN chmod +x /usr/local/bin/bbc-a11y


### PR DESCRIPTION
## Summary

We are using `bbc-a11y@mag` in the dockerfile. This means new versions of bbc-a11y are using a pre-release version.

## Solution

Use `bbc-a11y` in the dockerfile.

