### PR TITLE
Stop yarn.lock from re-appearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tags
 node_modules
 lib/bundle.js
 .idea
+yarn.lock


### PR DESCRIPTION
We decided we prefer package-lock to yarn.lock, so let's stop it from accidentally re-appearing