### PR TITLE
Fix Text must be styled with units that are resizable in all browsers

### DIFF
--- a/features/standards/mag/design/06_content_resizing.feature
+++ b/features/standards/mag/design/06_content_resizing.feature
@@ -60,7 +60,7 @@ Feature: Content resizing
   with browser tools to resize content.
 
   @html @automated
-  Scenario: Text must be styled with units that are resizable in all browsers
+  Scenario: px styles inline and stylesheet
     Given a page with the body:
       """
       <p style="font-size: 16px">Styled in px!</p>
@@ -73,6 +73,76 @@ Feature: Content resizing
       Text styled with px unit: /html/body/p
       Text styled with px unit: /html/body/b
       """
+
+  @html @automated
+  Scenario: pt styles inline and stylesheet
+    Given a page with the body:
+      """
+      <p style="font-size: 16pt">Styled in pt!</p>
+      <style>b { font-size: 18pt }</style>
+      <b>Styled in pt!</b>
+      """
+    When I test the "Design: Content resizing: Text must be styled with units that are resizable in all browsers" standard
+    Then it fails with the message:
+      """
+      Text styled with pt unit: /html/body/p
+      Text styled with pt unit: /html/body/b
+      """
+
+  @html @automated
+  Scenario: em styles inline and stylesheet
+    Given a page with the body:
+      """
+      <p style="font-size: 16em">Styled in em!</p>
+      <style>b { font-size: 1.5em }</style>
+      <b>Styled in em!</b>
+      """
+    When I test the "Design: Content resizing: Text must be styled with units that are resizable in all browsers" standard
+    Then it passes
+
+  @html @automated
+  Scenario: em and px styles
+    Given a page with the body:
+      """
+      <style>
+        body { font-size: 20px }
+        b { font-size: 1.5em }
+      </style>
+      <b>Styled in em but has px in the styles tree!</b>
+      """
+    When I test the "Design: Content resizing: Text must be styled with units that are resizable in all browsers" standard
+    Then it fails with the message:
+      """
+      Text styled with px unit: /html/body/b
+      """
+
+  @html @automated
+  Scenario: em and pt styles
+    Given a page with the body:
+      """
+      <style>
+        body { font-size: 20pt }
+        b { font-size: 1.5em }
+      </style>
+      <b>Styled in em!</b>
+      """
+    When I test the "Design: Content resizing: Text must be styled with units that are resizable in all browsers" standard
+    Then it fails with the message:
+      """
+      Text styled with pt unit: /html/body/b
+      """
+
+  @html @automated
+  Scenario: px overriden by em styles
+    Given a page with the body:
+      """
+      <style>
+        b { font-size: 12px; font-size: 1.5em; }
+      </style>
+      <b>Styled in em!</b>
+      """
+    When I test the "Design: Content resizing: Text must be styled with units that are resizable in all browsers" standard
+    Then it passes
 
   @html @automated
   Scenario: Small text

--- a/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
+++ b/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
@@ -6,6 +6,7 @@ module.exports = {
   failsForEach: 'text node that descends from an element styled with a px unit',
 
   test: function ({ $, fail }) {
+    var disallowedUnits = ['px', 'pt'];
     var textNodes = $('*:not(head, script, style):visible').contents().filter(function () {
       return this.nodeType === 3 && this.textContent.trim().length > 0
     })
@@ -18,16 +19,46 @@ module.exports = {
       }
     })
 
-    var temporaryStyleTag = document.createElement('style')
-    temporaryStyleTag.innerText = '* { font-size: 666px }'
-    $('head')[0].appendChild(temporaryStyleTag)
-    for (var i = 0; i < parents.length; ++i) {
-      var element = $(parents[i])
-      var fontSize = element.css('fontSize')
-      if (fontSize.indexOf('px') > -1 && fontSize !== '666px') {
-        fail('Text styled with px unit:', element)
+    for (var parentIndex in parents) {
+      var element = $(parents[parentIndex])
+      var fontSizes = getElementFontSizes(element)
+
+      for (var disallowedUnitIndex in disallowedUnits) {
+        var disallowedUnit = disallowedUnits[disallowedUnitIndex]
+        if (fontSizesIncludeUnit(fontSizes, disallowedUnit)) {
+          fail('Text styled with ' + disallowedUnit + ' unit:', element)
+        }
       }
     }
-    $(temporaryStyleTag).remove()
   }
+}
+
+function getElementFontSizes (el) {
+  var sheets = el[0].ownerDocument.styleSheets
+  var fontSizes = []
+  for (var sheetIndex in sheets) {
+    var rules = sheets[sheetIndex].rules || sheets[sheetIndex].cssRules
+    for (var ruleIndex in rules) {
+      var fontSize = rules[ruleIndex].style && rules[ruleIndex].style['font-size']
+      var ruleMatches = el.is(rules[ruleIndex].selectorText) || el.closest(rules[ruleIndex].selectorText).length
+      if (fontSize && ruleMatches) {
+        fontSizes.push(rules[ruleIndex].style['font-size'])
+      }
+    }
+  }
+  var inlineStyle = el[0].style && el[0].style.fontSize
+  if (inlineStyle) {
+    fontSizes.push(inlineStyle)
+  }
+  return fontSizes
+}
+
+function fontSizesIncludeUnit (sizes, unit) {
+  for (var sizeIndex in sizes) {
+    var size = sizes[sizeIndex]
+    if (size.indexOf(unit) > -1) {
+      return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
Fixes https://github.com/bbc/bbc-a11y/issues/262 and https://github.com/bbc/bbc-a11y/issues/259