### PR TITLE
Allow inherit font-size

### DIFF
--- a/features/standards/mag/design/06_content_resizing.feature
+++ b/features/standards/mag/design/06_content_resizing.feature
@@ -146,6 +146,16 @@ Feature: Content resizing
       """
 
   @html @automated
+  Scenario: inherit styles
+    Given a page with the body:
+      """
+      <style>b { font-size: 1.5em }</style>
+      <b style="font-size: inherit;">Styled in em!</b>
+      """
+    When I test the "Design: Content resizing: Text must be styled with units that are resizable in all browsers" standard
+    Then it passes
+
+  @html @automated
   Scenario: pc styles inline and stylesheet
     Given a page with the body:
       """

--- a/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
+++ b/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
@@ -56,7 +56,7 @@ function getElementFontSizes (el) {
 function fontSizesIncludeUnit (sizes, unit) {
   for (var sizeIndex in sizes) {
     var size = sizes[sizeIndex]
-    if (size.indexOf(unit) > -1) {
+    if (new RegExp('[0-9.]+' + unit).test(size)) {
       return true
     }
   }


### PR DESCRIPTION
Fixes https://github.com/bbc/bbc-a11y/issues/268

Arises from https://github.com/bbc/bbc-a11y/pull/266, which was a fix for https://github.com/bbc/bbc-a11y/issues/262 and https://github.com/bbc/bbc-a11y/issues/246