### PR TITLE
Whitelist abbr tags with title

### DIFF
--- a/features/standards/mag/text_equivalents/03_tooltips_and_supplementary_information.feature
+++ b/features/standards/mag/text_equivalents/03_tooltips_and_supplementary_information.feature
@@ -78,6 +78,15 @@ Feature: Tooltips and supplementary information
     When I test the "Text equivalents: Tooltips and supplementary information: Title attributes only on inputs" standard
     Then it passes
 
+    @html @automated
+  Scenario: Abbreviation tag with title attribute
+    Given a page with the body:
+      """
+      <abbr title="Bob Bobbington">Bob</abbr>
+      """
+    When I test the "Text equivalents: Tooltips and supplementary information: Title attributes only on inputs" standard
+    Then it passes
+
   @html @automated
   Scenario: Title attribute duplicates content
     Given a page with the body:

--- a/lib/standards/tests/titleAttributesOnlyOnInputs.js
+++ b/lib/standards/tests/titleAttributesOnlyOnInputs.js
@@ -3,11 +3,11 @@ module.exports = {
 
   type: 'automated',
 
-  failsForEach: 'element that is not an input (input, button, textarea, select) ' +
-                'or iframe, but does have a title attribute',
+  failsForEach: 'element that is not an input (input, button, textarea, select), ' +
+                'iframe, or abbreviation but does have a title attribute',
 
   test: function ({ $, fail }) {
-    $('[title]:not(input, button, textarea, select, iframe):visible').each(function (index, element) {
+    $('[title]:not(input, button, textarea, select, iframe, abbr):visible').each(function (index, element) {
       fail('Non-input element has title attribute:', element)
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbc-a11y",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "BBC Accessibility standards checker",
   "main": "./bin/bbc-a11y.js",
   "directories": {},


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Adding abbreviation tags to the whitelist for tags allowed to have a title attribute.

## Motivation and Context

Fixing https://github.com/bbc/bbc-a11y/issues/281

## How Has This Been Tested?

Added a new test to the multi-tiers that covers the scenario of `<abbr>` with a title existing within a page.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
