### PR TITLE
add logic to accept aria or bg-image on button with no text

### DIFF
--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -27,10 +27,10 @@ module.exports = {
         const $field = $(field)
 
         if (hasBackgroundImage($field) && !hasAriaLabel($field)) {
-          return fail('Image button has no aria-label:', element)
+          fail('Image button has no aria-label:', element)
+        } else {
+          fail('Button has no text:', element)
         }
-
-        return fail('Button has no text:', element)
       })
   }
 }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -6,7 +6,7 @@ module.exports = {
   failsForEach: [
     'visible input element (<input>, <textarea> and <select>) with no title ' +
     "attribute or <label> element referring to it (in the label's for attribute)",
-    '<button> element with a combination of no text (or only whitespace as text) and no aria-label or no aria-labelledby or no background-image'
+    '<button> element with no text (or only whitespace as text) without an aria-label'
   ],
 
   test: function ({ $, fail }) {

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -23,13 +23,15 @@ module.exports = {
       .filter(function (index, field) {
         return !hasText($(field))
       })
-      .filter(function (index, field) {
+      .each(function (index, field) {
         const $field = $(field)
 
-        if (hasBackgroundImage($field) && !hasAriaLabel($field)) {
-          fail('Image button has no aria-label:', element)
+        if (hasBackgroundImage($field)) {
+          if (!hasAriaLabel($field)) {
+            fail('Image button has no aria-label:', field)
+          }
         } else {
-          fail('Button has no text:', element)
+          fail('Button has no text:', field)
         }
       })
   }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -25,10 +25,12 @@ module.exports = {
       })
       .filter(function (index, field) {
         const $field = $(field)
-        return !hasAriaLabel($field) && !hasAriaLabelledBy($field) && !hasBackgroundImage($field)
-      })
-      .each(function (index, element) {
-        fail('Button has no text with no aria-label or aria-labelledby or background-image:', element)
+
+        if (hasBackgroundImage($field) && !hasAriaLabel($field)) {
+          return fail('Image button has no aria-label:', element)
+        }
+
+        return fail('Button has no text:', element)
       })
   }
 }
@@ -47,10 +49,6 @@ function hasBackgroundImage (field) {
 }
 
 function hasAriaLabel (field) {
-  return stringHasCharacters(field.attr('aria-label'))
-}
-
-function hasAriaLabelledBy (field) {
   return stringHasCharacters(field.attr('aria-label'))
 }
 

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -6,7 +6,7 @@ module.exports = {
   failsForEach: [
     'visible input element (<input>, <textarea> and <select>) with no title ' +
     "attribute or <label> element referring to it (in the label's for attribute)",
-    '<button> element with no text (or only whitespace as text)'
+    '<button> element with a combination of no text (or only whitespace as text) and no aria-label or no aria-labelledby or no background-image'
   ],
 
   test: function ({ $, fail }) {
@@ -20,13 +20,38 @@ module.exports = {
       })
 
     $('button')
-      .filter(function (index, button) {
-        return $(button).text().trim() === ''
+      .filter(function (index, field) {
+        return !hasText($(field))
+      })
+      .filter(function (index, field) {
+        const $field = $(field)
+        return !hasAriaLabel($field) && !hasAriaLabelledBy($field) && !hasBackgroundImage($field)
       })
       .each(function (index, element) {
-        fail('Button has no text:', element)
+        fail('Button has no text with no aria-label or aria-labelledby or background-image:', element)
       })
   }
+}
+
+function stringHasCharacters (string) {
+  return Boolean(string && string.trim().length)
+}
+
+function hasText (field) {
+  return stringHasCharacters(field.text())
+}
+
+function hasBackgroundImage (field) {
+  const backgroundImage = field.css('background-image')
+  return stringHasCharacters(backgroundImage) && backgroundImage !== 'none'
+}
+
+function hasAriaLabel (field) {
+  return stringHasCharacters(field.attr('aria-label'))
+}
+
+function hasAriaLabelledBy (field) {
+  return stringHasCharacters(field.attr('aria-label'))
 }
 
 function hasIdOrLabel (field) {


### PR DESCRIPTION
Resolves https://github.com/bbc/bbc-a11y/issues/245

## Summary

Make it possible to have a button with no text as long as there is a supporting aria-label, aria-labelledby or a background-image.

## Details

Adds the logic in the tests for `Fields must have labels or titles` for buttons.

## Motivation and Context

We want this expected behaviour.

Given a page with the following markup:
```html
<button class="arrows__chevron"></button> /* .arrows__chevron has background-image style */
```
Then the test "Fields must have labels or titles" passes.

Given a page with the following markup:
```html
<button aria-label="Scroll carousel right"></button>
```
Then the test "Fields must have labels or titles" passes.

Given a page with the following markup:
```html
<button aria-labelledby="S1 itemTitle"></button>
```
Then the test "Fields must have labels or titles" passes.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
