### PR TITLE
Prevent bbc-a11y from crashing on invalid selectors

### DIFF
--- a/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
+++ b/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
@@ -40,7 +40,9 @@ function getElementFontSizes (el) {
     var rules = sheets[sheetIndex].rules || sheets[sheetIndex].cssRules
     for (var ruleIndex in rules) {
       var fontSize = rules[ruleIndex].style && rules[ruleIndex].style['font-size']
-      var ruleMatches = el.is(rules[ruleIndex].selectorText) || el.closest(rules[ruleIndex].selectorText).length
+      var matchingElements = document.querySelectorAll(rules[ruleIndex].selectorText)
+      var ruleMatches = [...matchingElements].includes(el[0]) || el[0].closest(rules[ruleIndex].selectorText)
+
       if (fontSize && ruleMatches) {
         fontSizes.push(rules[ruleIndex].style['font-size'])
       }

--- a/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
+++ b/lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers.js
@@ -41,7 +41,7 @@ function getElementFontSizes (el) {
     for (var ruleIndex in rules) {
       var fontSize = rules[ruleIndex].style && rules[ruleIndex].style['font-size']
       var matchingElements = document.querySelectorAll(rules[ruleIndex].selectorText)
-      var ruleMatches = [...matchingElements].includes(el[0]) || el[0].closest(rules[ruleIndex].selectorText)
+      var ruleMatches = [].slice.apply(matchingElements).includes(el[0]) || el[0].closest(rules[ruleIndex].selectorText)
 
       if (fontSize && ruleMatches) {
         fontSizes.push(rules[ruleIndex].style['font-size'])

--- a/test/textMustBeStyledWithUnitsThatAreResizableInAllBrowsersSpec.js
+++ b/test/textMustBeStyledWithUnitsThatAreResizableInAllBrowsersSpec.js
@@ -1,0 +1,87 @@
+/* eslint-env mocha */
+var standard = require('../lib/standards/tests/textMustBeStyledWithUnitsThatAreResizableInAllBrowsers')
+var $ = require('jquery')
+var expect = require('chai').expect
+
+beforeEach(function () {
+  $('body').html('')
+  $('style').remove()
+})
+
+describe('Font size units standard', function () {
+  it('ignores empty text nodes', function () {
+    $('<div style="font-size: 12px"></div>').appendTo('body')
+    var failures = []
+    var fail = function (failure, element) {
+      failures.push(failure)
+    }
+    standard.test({ $, fail })
+    expect(failures).to.eql([])
+  })
+
+  it('ignores comment nodes', function () {
+    $('<div style="font-size: 12px"><!-- this is a comment --></div>').appendTo('body')
+    var failures = []
+    var fail = function (failure) {
+      failures.push(failure)
+    }
+    standard.test({ $, fail })
+    expect(failures).to.eql([])
+  })
+
+  it('ignores hidden nodes', function () {
+    $('<div style="font-size: 12px; display: none">Lorem Ipsum</div>').appendTo('body')
+    var failures = []
+    var fail = function (failure) {
+      failures.push(failure)
+    }
+    standard.test({ $, fail })
+    expect(failures).to.eql([])
+  })
+
+  it('allows nodes sized with em units', function () {
+    $('<div style="font-size: 1em">Lorem Ipsum</div>').appendTo('body')
+    var failures = []
+    var fail = function (failure) {
+      failures.push(failure)
+    }
+    standard.test({ $, fail })
+    expect(failures).to.eql([])
+  })
+
+  it('fails on visible nodes sized with px units using inline styles', function () {
+    $('<div class="text" style="font-size: 12px">Lorem Ipsum</div>').appendTo('body')
+    var failures = []
+    var fail = function (failure, element) {
+      failures.push([failure, element])
+    }
+    standard.test({ $, fail })
+    expect(failures.length).to.eql(1)
+    expect(failures[0][0]).to.eq('Text styled with px unit:')
+    expect(failures[0][1][0]).to.eq($('.text')[0])
+  })
+
+  it('fails on visible nodes sized with px units using stylesheets', function () {
+    $('<style>.text { font-size: 14px; }</style>').appendTo('head')
+    $('<div class="text">Lorem Ipsum</div>').appendTo('body')
+    var failures = []
+    var fail = function (failure, element) {
+      failures.push([failure, element])
+    }
+    standard.test({ $, fail })
+    expect(failures.length).to.eql(1)
+    expect(failures[0][0]).to.eq('Text styled with px unit:')
+    expect(failures[0][1][0]).to.eq($('.text')[0])
+  })
+
+  it('works with CSS3 selectors', function () {
+    $('<style>.text:not(:disabled):not(.disabled):active:focus { font-size: 12px; }</style>').appendTo('head')
+    $('<div class="text"><a>Lorem Ipsum</a></div>').appendTo('body')
+    var failures = []
+    var fail = function (failure, element) {
+      failures.push([failure, element])
+    }
+    standard.test({ $, fail })
+    expect(failures.length).to.eql(0)
+  })
+})


### PR DESCRIPTION
## Summary

The text size standard attempts to match stylesheet rules to elements using `jQuery.is()`. However jQuery's selector engine (Sizzle) doesn't support some CSS3 selectors. This causes bbc-a11y to ungracefully crash with an error like

```
Unexpected Error Error: Syntax error, unrecognized expression: unsupported pseudo: active
    at Function.Sizzle.error (/path/redacted/node_modules/jquery/dist/jquery.js:1560:8)
    at PSEUDO (/path/redacted/node_modules/jquery/dist/jquery.js:1907:13)
    at matcherFromTokens (/path/redacted/node_modules/jquery/dist/jquery.js:2460:44)
    at Sizzle.compile (/path/redacted/node_modules/jquery/dist/jquery.js:2614:13)
    at Sizzle.select (/path/redacted/node_modules/jquery/dist/jquery.js:2700:16)
    at Sizzle (/path/redacted/node_modules/jquery/dist/jquery.js:862:9)
    at Function.Sizzle.matchesSelector (/path/redacted/node_modules/jquery/dist/jquery.js:1523:9)
    at Function.jQuery.filter (/path/redacted/node_modules/jquery/dist/jquery.js:2869:22)
    at winnow (/path/redacted/node_modules/jquery/dist/jquery.js:2858:16)
    at jQuery.fn.init.is (/path/redacted/node_modules/jquery/dist/jquery.js:2908:12)
```

Related issues: #275, #287

## Details

This PR swaps out the use of jQuery's `$.is()` and `$.closest()` for the equivalent standard JS. The functionality is exactly the same, it is able to handle any valid CSS selectors without crashing.

## How Has This Been Tested?

Manually tested. There wasn't an existing spec for the standard so I didn't bother adding any tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
