### PR TITLE
298 fix iframe errors for h1 and role main

### DIFF
--- a/lib/standards/tests/exactlyOneMainHeading.js
+++ b/lib/standards/tests/exactlyOneMainHeading.js
@@ -11,6 +11,7 @@ module.exports = {
     if (count === 0) {
       fail('Found 0 h1 elements.')
     } else if (count > 1) {
+      console.log('xxxx')
       fail('Found ' + count + ' h1 elements:', mainHeadings)
     }
   }

--- a/lib/standards/tests/exactlyOneMainHeading.js
+++ b/lib/standards/tests/exactlyOneMainHeading.js
@@ -5,13 +5,14 @@ module.exports = {
 
   failsForEach: 'visible <h1> element except the very first one',
 
+  topFrameOnly: true,
+
   test: function ({ $, fail }) {
     var mainHeadings = $('h1:visible')
     var count = mainHeadings.length
     if (count === 0) {
       fail('Found 0 h1 elements.')
     } else if (count > 1) {
-      console.log('xxxx')
       fail('Found ' + count + ' h1 elements:', mainHeadings)
     }
   }

--- a/lib/standards/tests/exactlyOneMainLandmark.js
+++ b/lib/standards/tests/exactlyOneMainLandmark.js
@@ -5,6 +5,8 @@ module.exports = {
 
   failsForEach: 'page with no landmark element (any element with role="main")',
 
+  topFrameOnly: true,
+
   test: function ({ $, fail }) {
     var mainLandmarks = $("[role='main']")
     var count = mainLandmarks.length

--- a/test/iframeSpec.js
+++ b/test/iframeSpec.js
@@ -26,18 +26,19 @@ describe('a11y testing in frames', function () {
     this.heading2 = doc3.getElementsByTagName('h3')[0]
   })
 
-  it('tests contents of iframes', function () {
-    a11y.test({ only: ['Structure: Headings: Exactly one main heading', 'Headings: Headings must be in ascending order'] })
-      .then(function (outcome) {
-        expect(outcome.results[0].errors).to.eql([
-          ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Found 0 h1 elements.'],
-          ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'Found 0 h1 elements.'],
-          ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'Found 0 h1 elements.']
-        ])
-        expect(outcome.results[1].warnings).to.eql([
-          ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'First heading was not a main heading:', { element: this.heading1, xpath: '/html/body/h3[1]' }],
-          ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'First heading was not a main heading:', { element: this.heading2, xpath: '/html/body/h3[1]' }]
-        ])
-      })
+  it('tests contents of iframes', async function () {
+    // this test will always pass because it is not set up correctly to use promises https://mochajs.org/#working-with-promises
+    // using async/await instead - https://mochajs.org/#using-async-await - however the test now hangs indefinitely. I suspect an unresolved promise somewhere in the code
+    const outcome = await a11y.test({ only: ['Structure: Headings: Exactly one main heading', 'Headings: Headings must be in ascending order'] })
+
+    expect(outcome.results[0].errors).to.eql([
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Found 0 h1 elements.'],
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'Found 0 h1 elements.'],
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'Found 0 h1 elements.']
+    ])
+    expect(outcome.results[1].warnings).to.eql([
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'First heading was not a main heading:', { element: this.heading1, xpath: '/html/body/h3[1]' }],
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'First heading was not a main heading:', { element: this.heading2, xpath: '/html/body/h3[1]' }]
+    ])
   })
 })

--- a/test/iframeSpec.js
+++ b/test/iframeSpec.js
@@ -24,13 +24,14 @@ describe('a11y testing in frames', function () {
 
     this.heading1 = doc2.getElementsByTagName('h3')[0]
     this.heading2 = doc3.getElementsByTagName('h3')[0]
+    this.anchor = doc.getElementsByTagName('a')[0]
   })
 
   it('tests contents of iframes', async function () {
-    const outcome = await a11y.test({ only: ['Principles: Anchors must have hrefs', 'Headings: Headings must be in ascending order'] })
+    const outcome = await a11y.test({ only: ['Principles: Anchors must have hrefs', 'Structure: Headings: Headings must be in ascending order'] })
 
     expect(outcome.results[0].errors).to.eql([
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Anchor has no href attribute:', { element: '', xpath: '/html/body/p/a'}]
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Anchor has no href attribute:', { element: this.anchor, xpath: '/html/body/p/a' }]
     ])
     expect(outcome.results[1].warnings).to.eql([
       ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'First heading was not a main heading:', { element: this.heading1, xpath: '/html/body/h3[1]' }],

--- a/test/iframeSpec.js
+++ b/test/iframeSpec.js
@@ -9,7 +9,7 @@ describe('a11y testing in frames', function () {
     this.iframe1 = document.querySelector('iframe')
     var doc = this.iframe1.contentWindow.document
     doc.open()
-    doc.write('<html><body><p>Second level</p><iframe src="about:blank"></iframe><iframe src="about:blank"></iframe></body></html>')
+    doc.write('<html><body><p>Second level <a>second level anchor</a></p><iframe src="about:blank"></iframe><iframe src="about:blank"></iframe></body></html>')
     doc.close()
     this.iframe2 = doc.body.querySelectorAll('iframe')[0]
     var doc2 = this.iframe2.contentWindow.document
@@ -27,14 +27,10 @@ describe('a11y testing in frames', function () {
   })
 
   it('tests contents of iframes', async function () {
-    // this test will always pass because it is not set up correctly to use promises https://mochajs.org/#working-with-promises
-    // using async/await instead - https://mochajs.org/#using-async-await - however the test now hangs indefinitely. I suspect an unresolved promise somewhere in the code
-    const outcome = await a11y.test({ only: ['Structure: Headings: Exactly one main heading', 'Headings: Headings must be in ascending order'] })
+    const outcome = await a11y.test({ only: ['Principles: Anchors must have hrefs', 'Headings: Headings must be in ascending order'] })
 
     expect(outcome.results[0].errors).to.eql([
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Found 0 h1 elements.'],
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'Found 0 h1 elements.'],
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'Found 0 h1 elements.']
+      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Anchor has no href attribute:', { element: '', xpath: '/html/body/p/a'}]
     ])
     expect(outcome.results[1].warnings).to.eql([
       ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'First heading was not a main heading:', { element: this.heading1, xpath: '/html/body/h3[1]' }],

--- a/test/iframeSpec.js
+++ b/test/iframeSpec.js
@@ -5,7 +5,7 @@ var $ = require('jquery')
 
 describe('a11y testing in frames', function () {
   beforeEach(function () {
-    $('body').html('<html><body><h1>Top level</h1><iframe src="about:blank"></iframe></body></html>')
+    $('body').html('<html><body><div role="main"><h1>Top level</h1><iframe src="about:blank"></iframe></div></body></html>')
     this.iframe1 = document.querySelector('iframe')
     var doc = this.iframe1.contentWindow.document
     doc.open()
@@ -28,14 +28,16 @@ describe('a11y testing in frames', function () {
   })
 
   it('tests contents of iframes', async function () {
-    const outcome = await a11y.test({ only: ['Principles: Anchors must have hrefs', 'Structure: Headings: Headings must be in ascending order'] })
+    const outcome = await a11y.test({ only: ['Principles: Anchors must have hrefs', 'Structure: Headings: Headings must be in ascending order', 'Structure: Headings: Exactly one main heading', 'Structure: Containers and landmarks: Exactly one main landmark'] })
 
     expect(outcome.results[0].errors).to.eql([
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, ':', 'Anchor has no href attribute:', { element: this.anchor, xpath: '/html/body/p/a' }]
+      ['In frame', { element: this.iframe1, xpath: '/html/body/div/iframe' }, ':', 'Anchor has no href attribute:', { element: this.anchor, xpath: '/html/body/p/a' }]
     ])
     expect(outcome.results[1].warnings).to.eql([
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'First heading was not a main heading:', { element: this.heading1, xpath: '/html/body/h3[1]' }],
-      ['In frame', { element: this.iframe1, xpath: '/html/body/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'First heading was not a main heading:', { element: this.heading2, xpath: '/html/body/h3[1]' }]
+      ['In frame', { element: this.iframe1, xpath: '/html/body/div/iframe' }, { element: this.iframe2, xpath: '/html/body/iframe[1]' }, ':', 'First heading was not a main heading:', { element: this.heading1, xpath: '/html/body/h3[1]' }],
+      ['In frame', { element: this.iframe1, xpath: '/html/body/div/iframe' }, { element: this.iframe3, xpath: '/html/body/iframe[2]' }, ':', 'First heading was not a main heading:', { element: this.heading2, xpath: '/html/body/h3[1]' }]
     ])
+    expect(outcome.results[2].errors).to.eql([])
+    expect(outcome.results[3].errors).to.eql([])
   })
 })


### PR DESCRIPTION
Resolves https://github.com/bbc/bbc-a11y/issues/298

## Summary

Removes requirement for iframes to have exactly one main heading and exactly one main landmark

## Details

Adds `topFrameOnly: true` to `exactlyOneMainHeading.js` and `exactlyOneMainLandmark.js` to test configuration so that these tests will not run in iframes.

Fixes tests in `iframeSpec.js` that always pass because of incorrect async setup with use of promises. The fix uses async/await. Uses 'Principles: Anchors must have hrefs'  to test failures in iframes. Fixes the warnings tests in `tests contents of iframes` test by correcting `test.only` config to 'Structure: Headings: Headings must be in ascending order' it was missing `Structure: ` at the beginning. Adds tests to ensure no errors are returned when iframe does not have a main heading or landmark

## Motivation and Context

In BBC World Service the bbc-a11y tool fails for media embeds because they are contained within an iframe and they don't contain h1 elements or elements with a landmark.

## How Has This Been Tested?

Tests were fixed and more assertions added to no errors are returned when iframe does not have a main heading or landmark.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
