### PR TITLE
fieldsMustHaveLabelsOrTitles exception for no-text buttons with aria-labels

### DIFF
--- a/features/standards/mag/forms/01_labelling_form_controls.feature
+++ b/features/standards/mag/forms/01_labelling_form_controls.feature
@@ -125,7 +125,7 @@ Feature: Labelling form controls
   Scenario: Image inputs do not need labels or Title attributes
     Given a page with the body:
       """
-      <input type="image" />
+      <input type="image" src="next-icon.svg" alt="Next" />
       """
     When I test the "Forms: Labelling form controls: Fields must have labels or titles" standard
     Then it passes
@@ -148,5 +148,5 @@ Feature: Labelling form controls
     When I test the "Forms: Labelling form controls: Fields must have labels or titles" standard
     Then it fails with the message:
       """
-      Button has no text: /html/body/button
+      Button has no text or image: /html/body/button
       """

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -5,75 +5,99 @@ module.exports = {
 
   failsForEach: [
     'visible input element (<input>, <textarea> and <select>) with no title ' +
-    "attribute or <label> element referring to it (in the label's for attribute)",
-    '<button> element with no text (or only whitespace as text)'
+      "attribute or <label> element referring to it (in the label's for attribute)",
+    '<button> element with no text (or only whitespace as text)',
   ],
 
   test: function ({ $, fail }) {
-    $("input:visible:not([title], [type='hidden'], [type='submit'], [type='reset'], [type='image']), " +
-      'textarea:visible:not([title]), select:visible:not([title])')
-      .filter(function (index, field) {
-        return !hasIdOrLabel($(field))
-      })
-      .each(function (index, element) {
-        fail('Field has no label or title attribute:', element)
-      })
+    $(
+      "input:visible:not([title], [type='hidden'], [type='submit'], [type='reset'], [type='image']), " +
+        'textarea:visible:not([title]), select:visible:not([title])'
+    ).each(function (index, field) {
+      const $field = $(field);
+
+      if (!hasId($field) || !hasLabel($field)) {
+        fail('Field has no label or title attribute:', field);
+      }
+    });
+
+    $('input[type="image"]').each(function (index, field) {
+      const fieldSrc = $(field).attr('src');
+      const fieldAlt = $(field).attr('alt');
+
+      if (Boolean(fieldSrc && fieldSrc.trim()) === false) {
+        fail('Field with type of image has no src:', field);
+      }
+      if (Boolean(fieldAlt && fieldAlt.trim()) === false) {
+        fail('Field with type of image has no alt text:', field);
+      }
+    });
 
     $('button')
       .filter(function (index, button) {
-        const buttonHasNoText = $(button).text().trim() === ''
-        return buttonHasNoText
+        const buttonHasNoText = $(button).text().trim() === '';
+        return buttonHasNoText;
       })
       .filter(function (index, button) {
-        const buttonHasInlineImage = hasInlineImage($(button))
-        
-        if (buttonHasInlineImage) {
-          return true
+        const buttonHasInlineImage = hasInlineImage($(button));
+        const buttonHasBackgroundImage = hasBackgroundImage($(button));
+
+        console.log(buttonHasInlineImage, buttonHasBackgroundImage);
+        console.log($(button).css('background-image'));
+        if (buttonHasInlineImage || buttonHasBackgroundImage) {
+          return true;
         } else {
-          fail('Button has no text or inline icon image:', button)
-          return false
+          fail('Button has no text or image:', button);
+          return false;
         }
       })
       .filter(function (index, button) {
-        const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false
-        return buttonHasNoAriaLabel
+        const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false;
+        return buttonHasNoAriaLabel;
       })
       .filter(function (index, button) {
-        const buttonHasNoAriaLabelledBy = hasAriaLabelledBy($(button)) === false
-        return buttonHasNoAriaLabelledBy
+        const buttonHasNoAriaLabelledBy =
+          hasAriaLabelledBy($(button)) === false;
+        return buttonHasNoAriaLabelledBy;
       })
       .each(function (index, element) {
-        fail('Button with inline icon image has no aria-label or aria-labelledby:', element)
-      })
-  }
+        fail(
+          'Button with inline icon image has no aria-label or aria-labelledby:',
+          element
+        );
+      });
+  },
+};
+
+function hasId(field) {
+  return field.is('[id]');
 }
 
-function hasIdOrLabel (field) {
-  return hasId(field) || hasLabel(field)
+function hasLabel(field) {
+  var selector = "label[for='" + field.attr('id') + "']";
+  return field.parents('body').find(selector).length > 0;
 }
 
-function hasId (field) {
-  return field.is('[id]')
+function hasAriaLabel(field) {
+  var ariaLabel = field.attr('aria-label');
+  if (!ariaLabel) return false;
+  return ariaLabel.trim() !== '';
 }
 
-function hasLabel (field) {
-  var selector = "label[for='" + field.attr('id') + "']"
-  return field.parents('body').find(selector).length > 0
+function hasAriaLabelledBy(field) {
+  var ariaLabelledBy = field.attr('aria-labelledby');
+  if (!ariaLabelledBy) return false;
+  return ariaLabelledBy.trim() !== '';
 }
 
-function hasAriaLabel (field) {
-  var ariaLabel = field.attr('aria-label')
-  if (!ariaLabel) return false
-  return ariaLabel.trim() !== ''
+function hasInlineImage(field) {
+  var inlineImage = field.find('img, svg');
+  return Boolean(inlineImage.length);
 }
 
-function hasAriaLabelledBy (field) {
-  var ariaLabelledBy = field.attr('aria-labelledby')
-  if (!ariaLabelledBy) return false
-  return ariaLabelledBy.trim() !== ''
-}
-
-function hasInlineImage (field) {
-  var inlineImage = field.find('img, svg')
-  return Boolean(inlineImage.length)
+function hasBackgroundImage(field) {
+  const bgImage = field.css('background-image');
+  if (!bgImage) return false;
+  if (bgImage === 'none') return false;
+  return bgImage.trim() !== '';
 }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -72,7 +72,7 @@ module.exports = {
       })
       .each(function (index, element) {
         fail(
-          'Button with inline icon image has no aria-label or aria-labelledby:',
+          'Button with inline image or background image has no aria-label or aria-labelledby:',
           element
         )
       })

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -38,17 +38,7 @@ module.exports = {
         const buttonHasNoText = $(button).text().trim() === ''
         return buttonHasNoText
       })
-      .filter(function (index, button) {
-        const buttonHasInlineImage = hasInlineImage($(button))
-        const buttonHasBackgroundImage = hasBackgroundImage($(button))
 
-        if (buttonHasInlineImage || buttonHasBackgroundImage) {
-          return true
-        } else {
-          fail('Button has no text or image:', button)
-          return false
-        }
-      })
       .filter(function (index, button) {
         const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false
         return buttonHasNoAriaLabel
@@ -57,6 +47,28 @@ module.exports = {
         const buttonHasNoAriaLabelledBy =
           hasAriaLabelledBy($(button)) === false
         return buttonHasNoAriaLabelledBy
+      })
+      .filter(function (index, button) {
+        const buttonHasInlineImage = hasInlineImage($(button))
+        const buttonHasBackgroundImage = hasBackgroundImage($(button))
+
+        if (buttonHasInlineImage) {
+          const imageAlt = $(button).find('img').attr('alt')
+
+          if (Boolean(imageAlt && imageAlt.trim()) === false) {
+            fail(
+              'Button with no text with an inline image has no alt text:',
+              button
+            )
+          }
+          return false
+        }
+        if (buttonHasBackgroundImage) {
+          return true
+        } else {
+          fail('Button has no text or image:', button)
+          return false
+        }
       })
       .each(function (index, element) {
         fail(

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -6,7 +6,7 @@ module.exports = {
   failsForEach: [
     'visible input element (<input>, <textarea> and <select>) with no title ' +
       "attribute or <label> element referring to it (in the label's for attribute)",
-    '<button> element with no text (or only whitespace as text)',
+    '<button> element with no text (or only whitespace as text)'
   ],
 
   test: function ({ $, fail }) {
@@ -14,88 +14,88 @@ module.exports = {
       "input:visible:not([title], [type='hidden'], [type='submit'], [type='reset'], [type='image']), " +
         'textarea:visible:not([title]), select:visible:not([title])'
     ).each(function (index, field) {
-      const $field = $(field);
+      const $field = $(field)
 
       if (!hasId($field) || !hasLabel($field)) {
-        fail('Field has no label or title attribute:', field);
+        fail('Field has no label or title attribute:', field)
       }
-    });
+    })
 
     $('input[type="image"]').each(function (index, field) {
-      const fieldSrc = $(field).attr('src');
-      const fieldAlt = $(field).attr('alt');
+      const fieldSrc = $(field).attr('src')
+      const fieldAlt = $(field).attr('alt')
 
       if (Boolean(fieldSrc && fieldSrc.trim()) === false) {
-        fail('Field with type of image has no src:', field);
+        fail('Field with type of image has no src:', field)
       }
       if (Boolean(fieldAlt && fieldAlt.trim()) === false) {
-        fail('Field with type of image has no alt text:', field);
+        fail('Field with type of image has no alt text:', field)
       }
-    });
+    })
 
     $('button')
       .filter(function (index, button) {
-        const buttonHasNoText = $(button).text().trim() === '';
-        return buttonHasNoText;
+        const buttonHasNoText = $(button).text().trim() === ''
+        return buttonHasNoText
       })
       .filter(function (index, button) {
-        const buttonHasInlineImage = hasInlineImage($(button));
-        const buttonHasBackgroundImage = hasBackgroundImage($(button));
+        const buttonHasInlineImage = hasInlineImage($(button))
+        const buttonHasBackgroundImage = hasBackgroundImage($(button))
 
         if (buttonHasInlineImage || buttonHasBackgroundImage) {
-          return true;
+          return true
         } else {
-          fail('Button has no text or image:', button);
-          return false;
+          fail('Button has no text or image:', button)
+          return false
         }
       })
       .filter(function (index, button) {
-        const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false;
-        return buttonHasNoAriaLabel;
+        const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false
+        return buttonHasNoAriaLabel
       })
       .filter(function (index, button) {
         const buttonHasNoAriaLabelledBy =
-          hasAriaLabelledBy($(button)) === false;
-        return buttonHasNoAriaLabelledBy;
+          hasAriaLabelledBy($(button)) === false
+        return buttonHasNoAriaLabelledBy
       })
       .each(function (index, element) {
         fail(
           'Button with inline icon image has no aria-label or aria-labelledby:',
           element
-        );
-      });
-  },
-};
-
-function hasId(field) {
-  return field.is('[id]');
+        )
+      })
+  }
 }
 
-function hasLabel(field) {
-  var selector = "label[for='" + field.attr('id') + "']";
-  return field.parents('body').find(selector).length > 0;
+function hasId (field) {
+  return field.is('[id]')
 }
 
-function hasAriaLabel(field) {
-  var ariaLabel = field.attr('aria-label');
-  if (!ariaLabel) return false;
-  return ariaLabel.trim() !== '';
+function hasLabel (field) {
+  var selector = "label[for='" + field.attr('id') + "']"
+  return field.parents('body').find(selector).length > 0
 }
 
-function hasAriaLabelledBy(field) {
-  var ariaLabelledBy = field.attr('aria-labelledby');
-  if (!ariaLabelledBy) return false;
-  return ariaLabelledBy.trim() !== '';
+function hasAriaLabel (field) {
+  var ariaLabel = field.attr('aria-label')
+  if (!ariaLabel) return false
+  return ariaLabel.trim() !== ''
 }
 
-function hasInlineImage(field) {
-  var inlineImage = field.find('img, svg');
-  return Boolean(inlineImage.length);
+function hasAriaLabelledBy (field) {
+  var ariaLabelledBy = field.attr('aria-labelledby')
+  if (!ariaLabelledBy) return false
+  return ariaLabelledBy.trim() !== ''
 }
 
-function hasBackgroundImage(field) {
-  const bgImage = field.css('background-image');
-  if (!bgImage) return false;
-  if (bgImage === 'none') return false;
-  return bgImage.trim() !== '';
+function hasInlineImage (field) {
+  var inlineImage = field.find('img, svg')
+  return Boolean(inlineImage.length)
+}
+
+function hasBackgroundImage (field) {
+  const bgImage = field.css('background-image')
+  if (!bgImage) return false
+  if (bgImage === 'none') return false
+  return bgImage.trim() !== ''
 }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -25,6 +25,16 @@ module.exports = {
         return buttonHasNoText
       })
       .filter(function (index, button) {
+        const buttonHasInlineImage = hasInlineImage($(button))
+        
+        if (buttonHasInlineImage) {
+          return true
+        } else {
+          fail('Button has no text or inline icon image:', button)
+          return false
+        }
+      })
+      .filter(function (index, button) {
         const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false
         return buttonHasNoAriaLabel
       })
@@ -33,7 +43,7 @@ module.exports = {
         return buttonHasNoAriaLabelledBy
       })
       .each(function (index, element) {
-        fail('Button with no text has no aria-label or aria-labelledby:', element)
+        fail('Button with no text or inline icon image has no aria-label or aria-labelledby:', element)
       })
   }
 }
@@ -61,4 +71,9 @@ function hasAriaLabelledBy (field) {
   var ariaLabelledBy = field.attr('aria-labelledby')
   if (!ariaLabelledBy) return false
   return ariaLabelledBy.trim() !== ''
+}
+
+function hasInlineImage (field) {
+  var inlineImage = field.find('img, svg')
+  return Boolean(inlineImage.length)
 }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -43,7 +43,7 @@ module.exports = {
         return buttonHasNoAriaLabelledBy
       })
       .each(function (index, element) {
-        fail('Button with no text or inline icon image has no aria-label or aria-labelledby:', element)
+        fail('Button with inline icon image has no aria-label or aria-labelledby:', element)
       })
   }
 }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -28,8 +28,12 @@ module.exports = {
         const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false
         return buttonHasNoAriaLabel
       })
+      .filter(function (index, button) {
+        const buttonHasNoAriaLabelledBy = hasAriaLabelledBy($(button)) === false
+        return buttonHasNoAriaLabelledBy
+      })
       .each(function (index, element) {
-        fail('Button with no text has no aria-label:', element)
+        fail('Button with no text has no aria-label or aria-labelledby:', element)
       })
   }
 }
@@ -51,4 +55,10 @@ function hasAriaLabel (field) {
   var ariaLabel = field.attr('aria-label')
   if (!ariaLabel) return false
   return ariaLabel.trim() !== ''
+}
+
+function hasAriaLabelledBy (field) {
+  var ariaLabelledBy = field.attr('aria-labelledby')
+  if (!ariaLabelledBy) return false
+  return ariaLabelledBy.trim() !== ''
 }

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -42,8 +42,6 @@ module.exports = {
         const buttonHasInlineImage = hasInlineImage($(button));
         const buttonHasBackgroundImage = hasBackgroundImage($(button));
 
-        console.log(buttonHasInlineImage, buttonHasBackgroundImage);
-        console.log($(button).css('background-image'));
         if (buttonHasInlineImage || buttonHasBackgroundImage) {
           return true;
         } else {

--- a/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/standards/tests/fieldsMustHaveLabelsOrTitles.js
@@ -21,10 +21,15 @@ module.exports = {
 
     $('button')
       .filter(function (index, button) {
-        return $(button).text().trim() === ''
+        const buttonHasNoText = $(button).text().trim() === ''
+        return buttonHasNoText
+      })
+      .filter(function (index, button) {
+        const buttonHasNoAriaLabel = hasAriaLabel($(button)) === false
+        return buttonHasNoAriaLabel
       })
       .each(function (index, element) {
-        fail('Button has no text:', element)
+        fail('Button with no text has no aria-label:', element)
       })
   }
 }
@@ -40,4 +45,10 @@ function hasId (field) {
 function hasLabel (field) {
   var selector = "label[for='" + field.attr('id') + "']"
   return field.parents('body').find(selector).length > 0
+}
+
+function hasAriaLabel (field) {
+  var ariaLabel = field.attr('aria-label')
+  if (!ariaLabel) return false
+  return ariaLabel.trim() !== ''
 }

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -4,7 +4,36 @@ var expect = require('chai').expect
 var $ = require('jquery')
 
 describe('Fields must have labels or titles', function () {
-  it('should return an error when a button with no text has no aria-label ', async function () {
+  it('should return an error when a visible input element has no title', async function () {
+    $('body').html('<html><body><input></body></html>')
+    this.field = document.getElementsByTagName('input')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([
+      ['Field has no label or title attribute:', {'xpath': '/html/body/input', 'element': this.field }]
+    ])
+  })
+
+  it('should not return an error when a visible input element has a title', async function () {
+    $('body').html('<html><body><input title="input"></body></html>')
+    this.field = document.getElementsByTagName('input')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([])
+  })
+
+  it('should not return an error when a visible input element has a <label> element referring to it', async function () {
+    $('body').html('<html><body><label for="input">Label</label><input id="input"></body></html>')
+    this.field = document.getElementsByTagName('input')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([''])
+  })
+
+  it('should return an error when a button with no text has no aria-label', async function () {
     $('body').html('<html><body><button class="arrows__chevron"></button></body></html>')
     this.button = document.getElementsByTagName('button')[0]
 
@@ -15,7 +44,7 @@ describe('Fields must have labels or titles', function () {
     ])
   })
 
-  it('should not return an error when a button with no text has an aria-label ', async function () {
+  it('should not return an error when a button with no text has an aria-label', async function () {
     $('body').html('<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"></button></body></html>')
     this.button = document.getElementsByTagName('button')[0]
 

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -8,7 +8,7 @@ describe('Fields', function () {
     describe('Input with a title', function () {
       var testNode = '<input title="input">'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -24,7 +24,7 @@ describe('Fields', function () {
     describe('Image input with src and alt text', function () {
       var testNode = '<input type="image" src="next-icon.svg" alt="Next">'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -40,7 +40,7 @@ describe('Fields', function () {
     describe('Input with a <label> element referring to it', function () {
       var testNode = '<label for="input">Label</label><input id="input">'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -55,9 +55,9 @@ describe('Fields', function () {
 
     describe('Button with no text with an inline image with an aria-label', function () {
       var testNode =
-        '<button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button>'
+        '<button aria-label="Scroll carousel right"><img src="some-icon.png" /></button>'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -74,7 +74,7 @@ describe('Fields', function () {
       var testNode =
         '<button aria-labelledby="my_label"><img src="some-icon.png" /></button>'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -91,7 +91,7 @@ describe('Fields', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -108,7 +108,24 @@ describe('Fields', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>'
 
-      it('should not fail', async function () {
+      it('should pass', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>')
+
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
+
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
+
+    describe('Button with no text with an inline image with alt text', function () {
+      var testNode =
+        '<button><img src="some-icon.png" alt="Some icon" /></button>'
+
+      it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
@@ -145,7 +162,7 @@ describe('Fields', function () {
       })
     })
 
-    describe('Image input with no title', function () {
+    describe('Image input with alt text with no src attribute and no <label>', function () {
       var testNode = '<input type="image" alt="Next" />'
 
       it('should fail', async function () {
@@ -189,8 +206,8 @@ describe('Fields', function () {
       })
     })
 
-    describe('Button with no text and no image', function () {
-      var testNode = '<button class="arrows__chevron"></button>'
+    describe('Button with no text and no inline or background image', function () {
+      var testNode = '<button></button>'
 
       it('should fail', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
@@ -212,8 +229,7 @@ describe('Fields', function () {
     })
 
     describe('Button with no text and with an inline image with no aria-label or aria-labelledby', function () {
-      var testNode =
-        '<button class="arrows__chevron"><img src="some-icon.png" /></button>'
+      var testNode = '<button><img src="some-icon.png" /></button>'
 
       it('should fail', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
@@ -234,7 +250,7 @@ describe('Fields', function () {
       })
     })
 
-    describe('Button with no text and with a background image with no aria-label or aria-labelledby', function () {
+    describe('Button with no text and with an inline image with no alt text, no aria-label or aria-labelledby', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')"></button>'
 

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -1,75 +1,231 @@
 /* eslint-env mocha */
-var a11y = require('../lib/a11y.js')
-var expect = require('chai').expect
-var $ = require('jquery')
+var a11y = require('../lib/a11y.js');
+var expect = require('chai').expect;
+var $ = require('jquery');
 
-describe('Fields must have labels or titles', function () {
-  it('should return an error when a visible input element has no title', async function () {
-    $('body').html('<html><body><input></body></html>')
-    this.field = document.getElementsByTagName('input')[0]
+describe('Fields', function () {
+  describe('Accessible fields', function () {
+    it('should not return an error when a visible input element has a title', async function () {
+      $('body').html('<html><body><input title="input"></body></html>');
+      this.field = document.getElementsByTagName('input')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([
-      ['Field has no label or title attribute:', {'xpath': '/html/body/input', 'element': this.field }]
-    ])
-  })
+      expect(outcome.results[0].errors).to.eql([]);
+    });
 
-  it('should not return an error when a visible input element has a title', async function () {
-    $('body').html('<html><body><input title="input"></body></html>')
-    this.field = document.getElementsByTagName('input')[0]
+    it('should not return an error when a visible input element is of type image and has a src and alt attribute', async function () {
+      $('body').html(
+        '<html><body><input type="image" src="next-icon.svg" alt="Next"></body></html>'
+      );
+      this.field = document.getElementsByTagName('input')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([])
-  })
+      expect(outcome.results[0].errors).to.eql([]);
+    });
 
-  it('should not return an error when a visible input element has a <label> element referring to it', async function () {
-    $('body').html('<html><body><label for="input">Label</label><input id="input"></body></html>')
-    this.field = document.getElementsByTagName('input')[0]
+    it('should not return an error when a visible input element has a <label> element referring to it', async function () {
+      $('body').html(
+        '<html><body><label for="input">Label</label><input id="input"></body></html>'
+      );
+      this.field = document.getElementsByTagName('input')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([])
-  })
+      expect(outcome.results[0].errors).to.eql([]);
+    });
 
-  it('should return an error when a button has no text or no inline image', async function () {
-    $('body').html('<html><body><button class="arrows__chevron"></button></body></html>')
-    this.button = document.getElementsByTagName('button')[0]
+    it('should not return an error when a button with no text and an inline image has an aria-label', async function () {
+      $('body').html(
+        '<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([
-      ['Button has no text or inline icon image:', {'xpath': '/html/body/button', 'element': this.button }]
-    ])
-  })
+      expect(outcome.results[0].errors).to.eql([]);
+    });
 
-  it('should return an error when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
-    $('body').html('<html><body><button class="arrows__chevron"><img src="some-icon.png" /></button></body></html>')
-    this.button = document.getElementsByTagName('button')[0]
+    it('should not return an error when a button with no text and inline image has an aria-labelledby', async function () {
+      $('body').html(
+        '<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([
-      ['Button with no text or inline icon image has no aria-label or aria-labelledby:', {'xpath': '/html/body/button', 'element': this.button }]
-    ])
-  })
+      expect(outcome.results[0].errors).to.eql([]);
+    });
 
-  it('should not return an error when a button with no text and an inline image has an aria-label', async function () {
-    $('body').html('<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button></body></html>')
-    this.button = document.getElementsByTagName('button')[0]
+    it('should not return an error when a button with no text and background image CSS has an aria-labelledby', async function () {
+      $('body').html(
+        '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([])
-  })
+      expect(outcome.results[0].errors).to.eql([]);
+    });
 
-  it('should not return an error when a button with no text and inline image has an aria-labelledby', async function () {
-    $('body').html('<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button></body></html>')
-    this.button = document.getElementsByTagName('button')[0]
+    it('should not return an error when a button with no text and background image CSS has an aria-labelledby', async function () {
+      $('body').html(
+        '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
 
-    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
 
-    expect(outcome.results[0].errors).to.eql([])
-  })
-})
+      expect(outcome.results[0].errors).to.eql([]);
+    });
+  });
+
+  describe('Not accessible fields', function () {
+    it('should return an error when a visible input element has no title', async function () {
+      $('body').html('<html><body><input></body></html>');
+      this.field = document.getElementsByTagName('input')[0];
+
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
+
+      expect(outcome.results[0].errors).to.eql([
+        [
+          'Field has no label or title attribute:',
+          { xpath: '/html/body/input', element: this.field },
+        ],
+      ]);
+    });
+
+    it('should return an error when a visible input element is of type image and has no src', async function () {
+      $('body').html(
+        '<html><body><input type="image" alt="Next" /></body></html>'
+      );
+      this.field = document.getElementsByTagName('input')[0];
+
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
+
+      expect(outcome.results[0].errors).to.eql([
+        [
+          'Field with type of image has no src:',
+          { xpath: '/html/body/input', element: this.field },
+        ],
+      ]);
+    });
+
+    it('should return an error when a visible input element is of type image and has no alt attribute', async function () {
+      $('body').html(
+        '<html><body><input type="image" src="next-icon.svg" /></body></html>'
+      );
+      this.field = document.getElementsByTagName('input')[0];
+
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
+
+      expect(outcome.results[0].errors).to.eql([
+        [
+          'Field with type of image has no alt text:',
+          { xpath: '/html/body/input', element: this.field },
+        ],
+      ]);
+    });
+
+    it('should return an error when a button has no text or no inline image', async function () {
+      $('body').html(
+        '<html><body><button class="arrows__chevron"></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
+
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
+
+      expect(outcome.results[0].errors).to.eql([
+        [
+          'Button has no text or image:',
+          { xpath: '/html/body/button', element: this.button },
+        ],
+      ]);
+    });
+
+    it('should return an error when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
+      $('body').html(
+        '<html><body><button class="arrows__chevron"><img src="some-icon.png" /></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
+
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
+
+      expect(outcome.results[0].errors).to.eql([
+        [
+          'Button with inline icon image has no aria-label or aria-labelledby:',
+          { xpath: '/html/body/button', element: this.button },
+        ],
+      ]);
+    });
+
+    it('should return an error when a button with no text and a background image has no aria-label or aria-labelledby', async function () {
+      $('body').html(
+        '<html><body><button style="background-image: url(\'next-icon.svg\')"></button></body></html>'
+      );
+      this.button = document.getElementsByTagName('button')[0];
+
+      const outcome = await a11y.test({
+        only: [
+          'Forms: Labelling form controls: Fields must have labels or titles',
+        ],
+      });
+
+      expect(outcome.results[0].errors).to.eql([
+        [
+          'Button with inline icon image has no aria-label or aria-labelledby:',
+          { xpath: '/html/body/button', element: this.button },
+        ],
+      ]);
+    });
+  });
+});

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -1,262 +1,260 @@
 /* eslint-env mocha */
-var a11y = require('../lib/a11y.js');
-var expect = require('chai').expect;
-var $ = require('jquery');
+var a11y = require('../lib/a11y.js')
+var expect = require('chai').expect
+var $ = require('jquery')
 
 describe('Fields', function () {
   describe('Accessible fields', function () {
     describe('Input with a title', function () {
-      var testNode = '<input title="input">';
+      var testNode = '<input title="input">'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
 
     describe('Image input with src and alt text', function () {
-      var testNode = '<input type="image" src="next-icon.svg" alt="Next">';
+      var testNode = '<input type="image" src="next-icon.svg" alt="Next">'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
 
     describe('Input with a <label> element referring to it', function () {
-      var testNode = '<label for="input">Label</label><input id="input">';
+      var testNode = '<label for="input">Label</label><input id="input">'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('input')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
 
     describe('Button with no text with an inline image with an aria-label', function () {
       var testNode =
-        '<button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button>';
+        '<button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button>'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
 
     describe('Button with no text with an inline image with an aria-labelledby', function () {
       var testNode =
-        '<button aria-labelledby="my_label"><img src="some-icon.png" /></button>';
+        '<button aria-labelledby="my_label"><img src="some-icon.png" /></button>'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
 
     describe('Button with no text with a background image with an aria-label', function () {
       var testNode =
-        '<button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>';
+        '<button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('button')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
 
     describe('Button with no text with a background image with an aria-labelledby', function () {
       var testNode =
-        '<button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>';
+        '<button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>'
 
       it('should not fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
+        $('body').html('<html><body>' + testNode + '</body></html>')
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
-        expect(outcome.results[0].errors).to.eql([]);
-      });
-    });
-  });
+        expect(outcome.results[0].errors).to.eql([])
+      })
+    })
+  })
 
   describe('Not accessible fields', function () {
     describe('Input with no title', function () {
-      var testNode = '<input>';
+      var testNode = '<input>'
 
       it('should fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('input')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('input')[0]
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
         expect(outcome.results[0].errors).to.eql([
           [
             'Field has no label or title attribute:',
-            { xpath: '/html/body/input', element: el },
-          ],
-        ]);
-      });
-    });
+            { xpath: '/html/body/input', element: el }
+          ]
+        ])
+      })
+    })
 
     describe('Image input with no title', function () {
-      var testNode = '<input type="image" alt="Next" />';
+      var testNode = '<input type="image" alt="Next" />'
 
       it('should fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('input')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('input')[0]
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
         expect(outcome.results[0].errors).to.eql([
           [
             'Field with type of image has no src:',
-            { xpath: '/html/body/input', element: el },
-          ],
-        ]);
-      });
-    });
+            { xpath: '/html/body/input', element: el }
+          ]
+        ])
+      })
+    })
 
     describe('Image input with no alt text', function () {
-      var testNode = '<input type="image" src="next-icon.svg" />';
+      var testNode = '<input type="image" src="next-icon.svg" />'
 
       it('should fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('input')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('input')[0]
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
         expect(outcome.results[0].errors).to.eql([
           [
             'Field with type of image has no alt text:',
-            { xpath: '/html/body/input', element: el },
-          ],
-        ]);
-      });
-    });
+            { xpath: '/html/body/input', element: el }
+          ]
+        ])
+      })
+    })
 
     describe('Button with no text and no image', function () {
-      var testNode = '<button class="arrows__chevron"></button>';
+      var testNode = '<button class="arrows__chevron"></button>'
 
       it('should fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('button')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('button')[0]
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
         expect(outcome.results[0].errors).to.eql([
           [
             'Button has no text or image:',
-            { xpath: '/html/body/button', element: el },
-          ],
-        ]);
-      });
-    });
+            { xpath: '/html/body/button', element: el }
+          ]
+        ])
+      })
+    })
 
     describe('Button with no text and with an inline image with no aria-label or aria-labelledby', function () {
       var testNode =
-        '<button class="arrows__chevron"><img src="some-icon.png" /></button>';
+        '<button class="arrows__chevron"><img src="some-icon.png" /></button>'
 
       it('should fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('button')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('button')[0]
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
         expect(outcome.results[0].errors).to.eql([
           [
             'Button with inline icon image has no aria-label or aria-labelledby:',
-            { xpath: '/html/body/button', element: el },
-          ],
-        ]);
-      });
-    });
+            { xpath: '/html/body/button', element: el }
+          ]
+        ])
+      })
+    })
 
     describe('Button with no text and with a background image with no aria-label or aria-labelledby', function () {
       var testNode =
-        '<button style="background-image: url(\'next-icon.svg\')"></button>';
+        '<button style="background-image: url(\'next-icon.svg\')"></button>'
 
       it('should fail', async function () {
-        $('body').html('<html><body>' + testNode + '</body></html>');
-        var el = document.getElementsByTagName('button')[0];
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('button')[0]
 
         const outcome = await a11y.test({
           only: [
-            'Forms: Labelling form controls: Fields must have labels or titles',
-          ],
-        });
+            'Forms: Labelling form controls: Fields must have labels or titles'
+          ]
+        })
 
         expect(outcome.results[0].errors).to.eql([
           [
             'Button with inline icon image has no aria-label or aria-labelledby:',
-            { xpath: '/html/body/button', element: el },
-          ],
-        ]);
-      });
-    });
-  });
-});
+            { xpath: '/html/body/button', element: el }
+          ]
+        ])
+      })
+    })
+  })
+})

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -6,8 +6,9 @@ var $ = require('jquery');
 describe('Fields', function () {
   describe('Accessible fields', function () {
     it('should not fail when a visible input element has a title', async function () {
-      $('body').html('<html><body><input title="input"></body></html>');
-      this.field = document.getElementsByTagName('input')[0];
+      var testNode = '<input title="input">';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
 
       const outcome = await a11y.test({
         only: [
@@ -19,10 +20,9 @@ describe('Fields', function () {
     });
 
     it('should not fail when a visible input element is of type image and has a src and alt attribute', async function () {
-      $('body').html(
-        '<html><body><input type="image" src="next-icon.svg" alt="Next"></body></html>'
-      );
-      this.field = document.getElementsByTagName('input')[0];
+      var testNode = '<input type="image" src="next-icon.svg" alt="Next">';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
 
       const outcome = await a11y.test({
         only: [
@@ -34,10 +34,10 @@ describe('Fields', function () {
     });
 
     it('should not fail when a visible input element has a <label> element referring to it', async function () {
-      $('body').html(
-        '<html><body><label for="input">Label</label><input id="input"></body></html>'
-      );
-      this.field = document.getElementsByTagName('input')[0];
+      var testNode = '<label for="input">Label</label><input id="input">';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('input')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -49,10 +49,10 @@ describe('Fields', function () {
     });
 
     it('should not fail when a button with no text and an inline image has an aria-label', async function () {
-      $('body').html(
-        '<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode =
+        '<button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button>';
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -64,10 +64,11 @@ describe('Fields', function () {
     });
 
     it('should not fail when a button with no text and inline image has an aria-labelledby', async function () {
-      $('body').html(
-        '<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode =
+        '<div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button>';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -79,10 +80,11 @@ describe('Fields', function () {
     });
 
     it('should not fail when a button with no text and background image CSS has an aria-label', async function () {
-      $('body').html(
-        '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode =
+        '<div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -94,10 +96,11 @@ describe('Fields', function () {
     });
 
     it('should not fail when a button with no text and background image CSS has an aria-labelledby', async function () {
-      $('body').html(
-        '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode =
+        '<div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -111,8 +114,10 @@ describe('Fields', function () {
 
   describe('Not accessible fields', function () {
     it('should fail when a visible input element has no title', async function () {
-      $('body').html('<html><body><input></body></html>');
-      this.field = document.getElementsByTagName('input')[0];
+      var testNode = '<input>';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('input')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -123,16 +128,16 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([
         [
           'Field has no label or title attribute:',
-          { xpath: '/html/body/input', element: this.field },
+          { xpath: '/html/body/input', element: el },
         ],
       ]);
     });
 
     it('should fail when a visible input element is of type image and has no src', async function () {
-      $('body').html(
-        '<html><body><input type="image" alt="Next" /></body></html>'
-      );
-      this.field = document.getElementsByTagName('input')[0];
+      var testNode = '<input type="image" alt="Next" />';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('input')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -143,16 +148,16 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([
         [
           'Field with type of image has no src:',
-          { xpath: '/html/body/input', element: this.field },
+          { xpath: '/html/body/input', element: el },
         ],
       ]);
     });
 
     it('should fail when a visible input element is of type image and has no alt attribute', async function () {
-      $('body').html(
-        '<html><body><input type="image" src="next-icon.svg" /></body></html>'
-      );
-      this.field = document.getElementsByTagName('input')[0];
+      var testNode = '<input type="image" src="next-icon.svg" />';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('input')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -163,16 +168,16 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([
         [
           'Field with type of image has no alt text:',
-          { xpath: '/html/body/input', element: this.field },
+          { xpath: '/html/body/input', element: el },
         ],
       ]);
     });
 
     it('should fail when a button has no text or no image', async function () {
-      $('body').html(
-        '<html><body><button class="arrows__chevron"></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode = '<button class="arrows__chevron"></button>';
+
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -183,16 +188,16 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([
         [
           'Button has no text or image:',
-          { xpath: '/html/body/button', element: this.button },
+          { xpath: '/html/body/button', element: el },
         ],
       ]);
     });
 
     it('should fail when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
-      $('body').html(
-        '<html><body><button class="arrows__chevron"><img src="some-icon.png" /></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode =
+        '<button class="arrows__chevron"><img src="some-icon.png" /></button>';
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -203,16 +208,16 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([
         [
           'Button with inline icon image has no aria-label or aria-labelledby:',
-          { xpath: '/html/body/button', element: this.button },
+          { xpath: '/html/body/button', element: el },
         ],
       ]);
     });
 
     it('should fail when a button with no text and a background image has no aria-label or aria-labelledby', async function () {
-      $('body').html(
-        '<html><body><button style="background-image: url(\'next-icon.svg\')"></button></body></html>'
-      );
-      this.button = document.getElementsByTagName('button')[0];
+      var testNode =
+        '<button style="background-image: url(\'next-icon.svg\')"></button>';
+      $('body').html('<html><body>' + testNode + '</body></html>');
+      var el = document.getElementsByTagName('button')[0];
 
       const outcome = await a11y.test({
         only: [
@@ -223,7 +228,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([
         [
           'Button with inline icon image has no aria-label or aria-labelledby:',
-          { xpath: '/html/body/button', element: this.button },
+          { xpath: '/html/body/button', element: el },
         ],
       ]);
     });

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -30,7 +30,7 @@ describe('Fields must have labels or titles', function () {
 
     const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
 
-    expect(outcome.results[0].errors).to.eql([''])
+    expect(outcome.results[0].errors).to.eql([])
   })
 
   it('should return an error when a button with no text has no aria-label', async function () {

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -125,7 +125,7 @@ describe('Fields', function () {
   });
 
   describe('Not accessible fields', function () {
-    describe('Input element with no title', function () {
+    describe('Input with no title', function () {
       var testNode = '<input>';
 
       it('should fail', async function () {

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -5,234 +5,258 @@ var $ = require('jquery');
 
 describe('Fields', function () {
   describe('Accessible fields', function () {
-    it('should not fail when a visible input element has a title', async function () {
+    describe('Input with a title', function () {
       var testNode = '<input title="input">';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not fail when a visible input element is of type image and has a src and alt attribute', async function () {
+    describe('Image input with src and alt text', function () {
       var testNode = '<input type="image" src="next-icon.svg" alt="Next">';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not fail when a visible input element has a <label> element referring to it', async function () {
+    describe('Input with a <label> element referring to it', function () {
       var testNode = '<label for="input">Label</label><input id="input">';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('input')[0];
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('input')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not fail when a button with no text and an inline image has an aria-label', async function () {
+    describe('Button with no text with an inline image with an aria-label', function () {
       var testNode =
         '<button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button>';
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not fail when a button with no text and inline image has an aria-labelledby', async function () {
+    describe('Button with no text with an inline image with an aria-labelledby', function () {
       var testNode =
         '<button aria-labelledby="my_label"><img src="some-icon.png" /></button>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not fail when a button with no text and background image CSS has an aria-label', async function () {
+    describe('Button with no text with a background image with an aria-label', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('button')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not fail when a button with no text and background image CSS has an aria-labelledby', async function () {
+    describe('Button with no text with a background image with an aria-labelledby', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
+      it('should not fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([]);
       });
-
-      expect(outcome.results[0].errors).to.eql([]);
     });
   });
 
   describe('Not accessible fields', function () {
-    it('should fail when a visible input element has no title', async function () {
+    describe('Input element with no title', function () {
       var testNode = '<input>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('input')[0];
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('input')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([
+          [
+            'Field has no label or title attribute:',
+            { xpath: '/html/body/input', element: el },
+          ],
+        ]);
       });
-
-      expect(outcome.results[0].errors).to.eql([
-        [
-          'Field has no label or title attribute:',
-          { xpath: '/html/body/input', element: el },
-        ],
-      ]);
     });
 
-    it('should fail when a visible input element is of type image and has no src', async function () {
+    describe('Image input with no title', function () {
       var testNode = '<input type="image" alt="Next" />';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('input')[0];
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('input')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([
+          [
+            'Field with type of image has no src:',
+            { xpath: '/html/body/input', element: el },
+          ],
+        ]);
       });
-
-      expect(outcome.results[0].errors).to.eql([
-        [
-          'Field with type of image has no src:',
-          { xpath: '/html/body/input', element: el },
-        ],
-      ]);
     });
 
-    it('should fail when a visible input element is of type image and has no alt attribute', async function () {
+    describe('Image input with no alt text', function () {
       var testNode = '<input type="image" src="next-icon.svg" />';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('input')[0];
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('input')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([
+          [
+            'Field with type of image has no alt text:',
+            { xpath: '/html/body/input', element: el },
+          ],
+        ]);
       });
-
-      expect(outcome.results[0].errors).to.eql([
-        [
-          'Field with type of image has no alt text:',
-          { xpath: '/html/body/input', element: el },
-        ],
-      ]);
     });
 
-    it('should fail when a button has no text or no image', async function () {
+    describe('Button with no text and no image', function () {
       var testNode = '<button class="arrows__chevron"></button>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('button')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([
+          [
+            'Button has no text or image:',
+            { xpath: '/html/body/button', element: el },
+          ],
+        ]);
       });
-
-      expect(outcome.results[0].errors).to.eql([
-        [
-          'Button has no text or image:',
-          { xpath: '/html/body/button', element: el },
-        ],
-      ]);
     });
 
-    it('should fail when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
+    describe('Button with no text and with an inline image with no aria-label or aria-labelledby', function () {
       var testNode =
         '<button class="arrows__chevron"><img src="some-icon.png" /></button>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('button')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([
+          [
+            'Button with inline icon image has no aria-label or aria-labelledby:',
+            { xpath: '/html/body/button', element: el },
+          ],
+        ]);
       });
-
-      expect(outcome.results[0].errors).to.eql([
-        [
-          'Button with inline icon image has no aria-label or aria-labelledby:',
-          { xpath: '/html/body/button', element: el },
-        ],
-      ]);
     });
 
-    it('should fail when a button with no text and a background image has no aria-label or aria-labelledby', async function () {
+    describe('Button with no text and with a background image with no aria-label or aria-labelledby', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')"></button>';
 
-      $('body').html('<html><body>' + testNode + '</body></html>');
-      var el = document.getElementsByTagName('button')[0];
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>');
+        var el = document.getElementsByTagName('button')[0];
 
-      const outcome = await a11y.test({
-        only: [
-          'Forms: Labelling form controls: Fields must have labels or titles',
-        ],
+        const outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles',
+          ],
+        });
+
+        expect(outcome.results[0].errors).to.eql([
+          [
+            'Button with inline icon image has no aria-label or aria-labelledby:',
+            { xpath: '/html/body/button', element: el },
+          ],
+        ]);
       });
-
-      expect(outcome.results[0].errors).to.eql([
-        [
-          'Button with inline icon image has no aria-label or aria-labelledby:',
-          { xpath: '/html/body/button', element: el },
-        ],
-      ]);
     });
   });
 });

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -5,7 +5,7 @@ var $ = require('jquery');
 
 describe('Fields', function () {
   describe('Accessible fields', function () {
-    it('should not return an error when a visible input element has a title', async function () {
+    it('should not fail when a visible input element has a title', async function () {
       $('body').html('<html><body><input title="input"></body></html>');
       this.field = document.getElementsByTagName('input')[0];
 
@@ -18,7 +18,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a visible input element is of type image and has a src and alt attribute', async function () {
+    it('should not fail when a visible input element is of type image and has a src and alt attribute', async function () {
       $('body').html(
         '<html><body><input type="image" src="next-icon.svg" alt="Next"></body></html>'
       );
@@ -33,7 +33,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a visible input element has a <label> element referring to it', async function () {
+    it('should not fail when a visible input element has a <label> element referring to it', async function () {
       $('body').html(
         '<html><body><label for="input">Label</label><input id="input"></body></html>'
       );
@@ -48,7 +48,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a button with no text and an inline image has an aria-label', async function () {
+    it('should not fail when a button with no text and an inline image has an aria-label', async function () {
       $('body').html(
         '<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button></body></html>'
       );
@@ -63,7 +63,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a button with no text and inline image has an aria-labelledby', async function () {
+    it('should not fail when a button with no text and inline image has an aria-labelledby', async function () {
       $('body').html(
         '<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button></body></html>'
       );
@@ -78,7 +78,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a button with no text and background image CSS has an aria-label', async function () {
+    it('should not fail when a button with no text and background image CSS has an aria-label', async function () {
       $('body').html(
         '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button></body></html>'
       );
@@ -93,7 +93,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a button with no text and background image CSS has an aria-labelledby', async function () {
+    it('should not fail when a button with no text and background image CSS has an aria-labelledby', async function () {
       $('body').html(
         '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button></body></html>'
       );
@@ -110,7 +110,7 @@ describe('Fields', function () {
   });
 
   describe('Not accessible fields', function () {
-    it('should return an error when a visible input element has no title', async function () {
+    it('should fail when a visible input element has no title', async function () {
       $('body').html('<html><body><input></body></html>');
       this.field = document.getElementsByTagName('input')[0];
 
@@ -128,7 +128,7 @@ describe('Fields', function () {
       ]);
     });
 
-    it('should return an error when a visible input element is of type image and has no src', async function () {
+    it('should fail when a visible input element is of type image and has no src', async function () {
       $('body').html(
         '<html><body><input type="image" alt="Next" /></body></html>'
       );
@@ -148,7 +148,7 @@ describe('Fields', function () {
       ]);
     });
 
-    it('should return an error when a visible input element is of type image and has no alt attribute', async function () {
+    it('should fail when a visible input element is of type image and has no alt attribute', async function () {
       $('body').html(
         '<html><body><input type="image" src="next-icon.svg" /></body></html>'
       );
@@ -168,7 +168,7 @@ describe('Fields', function () {
       ]);
     });
 
-    it('should return an error when a button has no text or no image', async function () {
+    it('should fail when a button has no text or no image', async function () {
       $('body').html(
         '<html><body><button class="arrows__chevron"></button></body></html>'
       );
@@ -188,7 +188,7 @@ describe('Fields', function () {
       ]);
     });
 
-    it('should return an error when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
+    it('should fail when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
       $('body').html(
         '<html><body><button class="arrows__chevron"><img src="some-icon.png" /></button></body></html>'
       );
@@ -208,7 +208,7 @@ describe('Fields', function () {
       ]);
     });
 
-    it('should return an error when a button with no text and a background image has no aria-label or aria-labelledby', async function () {
+    it('should fail when a button with no text and a background image has no aria-label or aria-labelledby', async function () {
       $('body').html(
         '<html><body><button style="background-image: url(\'next-icon.svg\')"></button></body></html>'
       );

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -65,7 +65,7 @@ describe('Fields', function () {
 
     it('should not fail when a button with no text and inline image has an aria-labelledby', async function () {
       var testNode =
-        '<div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button>';
+        '<button aria-labelledby="my_label"><img src="some-icon.png" /></button>';
 
       $('body').html('<html><body>' + testNode + '</body></html>');
       var el = document.getElementsByTagName('button')[0];
@@ -81,7 +81,7 @@ describe('Fields', function () {
 
     it('should not fail when a button with no text and background image CSS has an aria-label', async function () {
       var testNode =
-        '<div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>';
+        '<button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>';
 
       $('body').html('<html><body>' + testNode + '</body></html>');
       var el = document.getElementsByTagName('button')[0];
@@ -97,7 +97,7 @@ describe('Fields', function () {
 
     it('should not fail when a button with no text and background image CSS has an aria-labelledby', async function () {
       var testNode =
-        '<div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>';
+        '<button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>';
 
       $('body').html('<html><body>' + testNode + '</body></html>');
       var el = document.getElementsByTagName('button')[0];
@@ -196,6 +196,7 @@ describe('Fields', function () {
     it('should fail when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
       var testNode =
         '<button class="arrows__chevron"><img src="some-icon.png" /></button>';
+
       $('body').html('<html><body>' + testNode + '</body></html>');
       var el = document.getElementsByTagName('button')[0];
 
@@ -216,6 +217,7 @@ describe('Fields', function () {
     it('should fail when a button with no text and a background image has no aria-label or aria-labelledby', async function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')"></button>';
+
       $('body').html('<html><body>' + testNode + '</body></html>');
       var el = document.getElementsByTagName('button')[0];
 

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+var a11y = require('../lib/a11y.js')
+var expect = require('chai').expect
+var $ = require('jquery')
+
+describe('Fields must have labels or titles', function () {
+  it('should return an error when a button with no text has no aria-label ', async function () {
+    $('body').html('<html><body><button class="arrows__chevron"></button></body></html>')
+    this.button = document.getElementsByTagName('button')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([
+      ['Button with no text has no aria-label:', {'xpath': '/html/body/button', 'element': this.button }]
+    ])
+  })
+
+  it('should not return an error when a button with no text has an aria-label ', async function () {
+    $('body').html('<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"></button></body></html>')
+    this.button = document.getElementsByTagName('button')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([])
+  })
+})

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -228,7 +228,7 @@ describe('Fields', function () {
       })
     })
 
-    describe('Button with no text and with an inline image with no aria-label or aria-labelledby', function () {
+    describe('Button with no text with no aria-label or aria-labelledby containing an inline image with no alt text, ', function () {
       var testNode = '<button><img src="some-icon.png" /></button>'
 
       it('should fail', async function () {
@@ -243,7 +243,7 @@ describe('Fields', function () {
 
         expect(outcome.results[0].errors).to.eql([
           [
-            'Button with inline icon image has no aria-label or aria-labelledby:',
+            'Button with no text with an inline image has no alt text:',
             { xpath: '/html/body/button', element: el }
           ]
         ])

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -33,19 +33,30 @@ describe('Fields must have labels or titles', function () {
     expect(outcome.results[0].errors).to.eql([])
   })
 
-  it('should return an error when a button with no text has no aria-label', async function () {
+  it('should return an error when a button has no text or no inline image', async function () {
     $('body').html('<html><body><button class="arrows__chevron"></button></body></html>')
     this.button = document.getElementsByTagName('button')[0]
 
     const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
 
     expect(outcome.results[0].errors).to.eql([
-      ['Button with no text has no aria-label or aria-labelledby:', {'xpath': '/html/body/button', 'element': this.button }]
+      ['Button has no text or inline icon image:', {'xpath': '/html/body/button', 'element': this.button }]
     ])
   })
 
-  it('should not return an error when a button with no text has an aria-label', async function () {
-    $('body').html('<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"></button></body></html>')
+  it('should return an error when a button with no text and an inline image has no aria-label or aria-labelledby', async function () {
+    $('body').html('<html><body><button class="arrows__chevron"><img src="some-icon.png" /></button></body></html>')
+    this.button = document.getElementsByTagName('button')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([
+      ['Button with no text or inline icon image has no aria-label or aria-labelledby:', {'xpath': '/html/body/button', 'element': this.button }]
+    ])
+  })
+
+  it('should not return an error when a button with no text and an inline image has an aria-label', async function () {
+    $('body').html('<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"><img src="some-icon.png" /></button></body></html>')
     this.button = document.getElementsByTagName('button')[0]
 
     const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
@@ -53,8 +64,8 @@ describe('Fields must have labels or titles', function () {
     expect(outcome.results[0].errors).to.eql([])
   })
 
-  it('should not return an error when a button with no text has an aria-labelledby', async function () {
-    $('body').html('<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"></button></body></html>')
+  it('should not return an error when a button with no text and inline image has an aria-labelledby', async function () {
+    $('body').html('<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"><img src="some-icon.png" /></button></body></html>')
     this.button = document.getElementsByTagName('button')[0]
 
     const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -78,7 +78,7 @@ describe('Fields', function () {
       expect(outcome.results[0].errors).to.eql([]);
     });
 
-    it('should not return an error when a button with no text and background image CSS has an aria-labelledby', async function () {
+    it('should not return an error when a button with no text and background image CSS has an aria-label', async function () {
       $('body').html(
         '<html><body><div id="my_label">My label</div><button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button></body></html>'
       );
@@ -168,7 +168,7 @@ describe('Fields', function () {
       ]);
     });
 
-    it('should return an error when a button has no text or no inline image', async function () {
+    it('should return an error when a button has no text or no image', async function () {
       $('body').html(
         '<html><body><button class="arrows__chevron"></button></body></html>'
       );

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -40,12 +40,21 @@ describe('Fields must have labels or titles', function () {
     const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
 
     expect(outcome.results[0].errors).to.eql([
-      ['Button with no text has no aria-label:', {'xpath': '/html/body/button', 'element': this.button }]
+      ['Button with no text has no aria-label or aria-labelledby:', {'xpath': '/html/body/button', 'element': this.button }]
     ])
   })
 
   it('should not return an error when a button with no text has an aria-label', async function () {
     $('body').html('<html><body><button class="arrows__chevron" aria-label="Scroll carousel right"></button></body></html>')
+    this.button = document.getElementsByTagName('button')[0]
+
+    const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })
+
+    expect(outcome.results[0].errors).to.eql([])
+  })
+
+  it('should not return an error when a button with no text has an aria-labelledby', async function () {
+    $('body').html('<html><body><div id="my_label">My label</div><button aria-labelledby="my_label"></button></body></html>')
     this.button = document.getElementsByTagName('button')[0]
 
     const outcome = await a11y.test({ only: ['Forms: Labelling form controls: Fields must have labels or titles'] })

--- a/test/fieldsSpec.js
+++ b/test/fieldsSpec.js
@@ -11,13 +11,15 @@ describe('Fields', function () {
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
@@ -27,13 +29,15 @@ describe('Fields', function () {
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
@@ -43,47 +47,53 @@ describe('Fields', function () {
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
     describe('Button with no text with an inline image with an aria-label', function () {
       var testNode =
-        '<button aria-label="Scroll carousel right"><img src="some-icon.png" /></button>'
+        '<button aria-label="Scroll carousel right"><img src="some-icon.png" alt="" /></button>'
 
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
     describe('Button with no text with an inline image with an aria-labelledby', function () {
       var testNode =
-        '<button aria-labelledby="my_label"><img src="some-icon.png" /></button>'
+        '<button aria-labelledby="my_label"><img src="some-icon.png" alt="" /></button>'
 
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
@@ -94,13 +104,15 @@ describe('Fields', function () {
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
@@ -111,13 +123,15 @@ describe('Fields', function () {
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
 
@@ -128,13 +142,15 @@ describe('Fields', function () {
       it('should pass', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([])
+        var errors = outcome.results[0].errors
+
+        expect(errors).to.eql([])
       })
     })
   })
@@ -147,18 +163,18 @@ describe('Fields', function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
         var el = document.getElementsByTagName('input')[0]
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([
-          [
-            'Field has no label or title attribute:',
-            { xpath: '/html/body/input', element: el }
-          ]
-        ])
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql('Field has no label or title attribute:')
+        expect(pathToNode).to.eql({ xpath: '/html/body/input', element: el })
       })
     })
 
@@ -169,18 +185,18 @@ describe('Fields', function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
         var el = document.getElementsByTagName('input')[0]
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([
-          [
-            'Field with type of image has no src:',
-            { xpath: '/html/body/input', element: el }
-          ]
-        ])
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql('Field with type of image has no src:')
+        expect(pathToNode).to.eql({ xpath: '/html/body/input', element: el })
       })
     })
 
@@ -191,18 +207,44 @@ describe('Fields', function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
         var el = document.getElementsByTagName('input')[0]
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([
-          [
-            'Field with type of image has no alt text:',
-            { xpath: '/html/body/input', element: el }
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql(
+          'Field with type of image has no alt text:'
+        )
+        expect(pathToNode).to.eql({ xpath: '/html/body/input', element: el })
+      })
+    })
+
+    describe('Image input with empty alt text', function () {
+      var testNode = '<input type="image" src="next-icon.svg" alt="" />'
+
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('input')[0]
+
+        var outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles'
           ]
-        ])
+        })
+
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql(
+          'Field with type of image has no alt text:'
+        )
+        expect(pathToNode).to.eql({ xpath: '/html/body/input', element: el })
       })
     })
 
@@ -213,44 +255,46 @@ describe('Fields', function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
         var el = document.getElementsByTagName('button')[0]
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([
-          [
-            'Button has no text or image:',
-            { xpath: '/html/body/button', element: el }
-          ]
-        ])
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql('Button has no text or image:')
+        expect(pathToNode).to.eql({ xpath: '/html/body/button', element: el })
       })
     })
 
-    describe('Button with no text with no aria-label or aria-labelledby containing an inline image with no alt text, ', function () {
+    describe('Button with no text with no aria-label or aria-labelledby containing an inline image with no alt text', function () {
       var testNode = '<button><img src="some-icon.png" /></button>'
 
       it('should fail', async function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
         var el = document.getElementsByTagName('button')[0]
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([
-          [
-            'Button with no text with an inline image has no alt text:',
-            { xpath: '/html/body/button', element: el }
-          ]
-        ])
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql(
+          'Button with no text with an inline image has no alt text:'
+        )
+        expect(pathToNode).to.eql({ xpath: '/html/body/button', element: el })
       })
     })
 
-    describe('Button with no text and with an inline image with no alt text, no aria-label or aria-labelledby', function () {
+    describe('Button with no text and with a background image with no aria-label or aria-labelledby', function () {
       var testNode =
         '<button style="background-image: url(\'next-icon.svg\')"></button>'
 
@@ -258,18 +302,45 @@ describe('Fields', function () {
         $('body').html('<html><body>' + testNode + '</body></html>')
         var el = document.getElementsByTagName('button')[0]
 
-        const outcome = await a11y.test({
+        var outcome = await a11y.test({
           only: [
             'Forms: Labelling form controls: Fields must have labels or titles'
           ]
         })
 
-        expect(outcome.results[0].errors).to.eql([
-          [
-            'Button with inline icon image has no aria-label or aria-labelledby:',
-            { xpath: '/html/body/button', element: el }
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql(
+          'Button with inline image or background image has no aria-label or aria-labelledby:'
+        )
+        expect(pathToNode).to.eql({ xpath: '/html/body/button', element: el })
+      })
+    })
+
+    describe('Input with no <label> element referring to it', function () {
+      var testNode = '<label>Label</label><input id="input">'
+
+      it('should fail', async function () {
+        $('body').html('<html><body>' + testNode + '</body></html>')
+        var el = document.getElementsByTagName('input')[0]
+
+        var outcome = await a11y.test({
+          only: [
+            'Forms: Labelling form controls: Fields must have labels or titles'
           ]
-        ])
+        })
+
+        var errors = outcome.results[0].errors[0]
+        var errorMessage = errors[0]
+        var pathToNode = errors[1]
+
+        expect(errorMessage).to.eql('Field has no label or title attribute:')
+        expect(pathToNode).to.eql({
+          xpath: "//input[@id='input']",
+          element: el
+        })
       })
     })
   })


### PR DESCRIPTION
Resolves https://github.com/bbc/bbc-a11y/issues/245

Adds support to allow buttons with no text to pass if they contain an inline image or background image in combination with aria-label or aria-labelledby attributes.

## Details
Adds functionality described above in `lib/standards/tests/fieldsMustHaveLabelsOrTitles.js` and adds unit tests to verify all rules work as expected.


Adds tests:

### Accessible fields

> Input with a title should pass
```html
<input title="input">
```

---

> Image input with src and alt text should pass
```html
<input type="image" src="next-icon.svg" alt="Next">
```

---

> Input with a label element referring to it should pass
```html
<label for="input">Label</label><input id="input">
```

---

> Button with no text with an inline image with an aria-label should pass
```html
<button aria-label="Scroll carousel right"><img src="some-icon.png" alt="" /></button>
```

---

> Button with no text with an inline image with an aria-labelledby should pass
```html
<button aria-labelledby="my_label"><img src="some-icon.png" alt="" /></button>
```

---

> Button with no text with a background image with an aria-label should pass
```html
<button style="background-image: url(\'next-icon.svg\')" aria-label="Next"></button>
```

---

> Button with no text with a background image with an aria-labelledby should pass
```html
<button style="background-image: url(\'next-icon.svg\')" aria-labelledby="Next"></button>
```

---

> Button with no text with an inline image with alt text should pass
```html
<button><img src="some-icon.png" alt="Some icon" /></button>
```

---

### Not accessible fields

> Input with no title should fail
> With message - Field has no label or title attribute
```html
<input>
```

---

> Image input with alt text with no src attribute and no label should fail
> With message - Field with type of image has no src
```html
<input type="image" alt="Next" />
```

---

> Image input with no alt text should fail
> With message - Field with type of image has no alt text
```html
<input type="image" src="next-icon.svg" />
```

---

> Image input with empty alt text should fail
> With message - Field with type of image has no alt text
```html
<input type="image" src="next-icon.svg" alt="" />
```

---

> Button with no text and no inline or background image should fail
> With message - Button has no text or image
```html
<button></button>
```

---

> Button with no text with no aria-label or aria-labelledby containing an inline image with no alt text should fail
> With message - Button with no text with an inline image has no alt text
```html
<button><img src="some-icon.png" /></button>
```

---

> Button with no text and with a background image with no aria-label or aria-labelledby should fail
> With message - Button with inline image or background image has no aria-label or aria-labelledby
```html
<button style="background-image: url(\'next-icon.svg\')"></button>
```

---

> Input with no <label> element referring to it should fail
> With message - Field has no label or title attribute
```html
<label>Label</label><input id="input">
```

---

---
## NB

Based on a comment by @EmmaJP https://github.com/bbc/bbc-a11y/pull/314#issuecomment-620799612

> Each of the following would be accessible and meaningful:
```
<button>Next</button>
<button aria-label="Next">&gt;</button>
<input type="image" src="next-icon.svg" alt="Next" />
```

I added tests to check for the presence of src and alt attributes for `<input type="image" />`. This broke a cucumber test that didn't check for src and alt attributes. Making this stricter is a breaking change. Should I have done this or left the functionality as it was?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
