### PR TITLE
Amend "Exactly one main landmark" check to allow for <main> tag

### DIFF
--- a/features/setting_cookies.feature
+++ b/features/setting_cookies.feature
@@ -28,11 +28,11 @@ Feature: Setting Cookies
 
       ✗ http://localhost:54321/good_with_cookie.html
         * Structure: Containers and landmarks: Exactly one main landmark
-          - Found 0 elements with role="main".
+          - Found 0 elements with <main> tag or role="main".
 
       ✗ http://localhost:54321/good_with_cookie.html
         * Structure: Containers and landmarks: Exactly one main landmark
-          - Found 0 elements with role="main".
+          - Found 0 elements with <main> tag or role="main".
 
       ✓ http://localhost:54321/good_with_cookie.html
       """

--- a/features/standards/mag/structure/03_containers_and_landmarks.feature
+++ b/features/standards/mag/structure/03_containers_and_landmarks.feature
@@ -16,7 +16,7 @@ Feature: Containers and landmarks
   HTML Applicability
   ==================
 
-  A page **must** have exactly one element with `role="main"`
+  A page **must** have exactly one element with a <main> tag or `role="main"`
 
   The WAI-ARIA `main` landmark role can be help keyboard users with assistive
   technologies such as screen readers (and in the future as native browser
@@ -24,10 +24,19 @@ Feature: Containers and landmarks
   navigation and other contents that might be before it.
 
   @html @automated
-  Scenario: Page has a single main element
+  Scenario: Page has a single main element with role="main"
     Given a page with the body:
       """
       <div role="main">Main element</div>
+      """
+    When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
+    Then it passes
+
+  @html @automated
+  Scenario: Page has a single main element with <main> tag
+    Given a page with the body:
+      """
+      <main>Main element</main>
       """
     When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
     Then it passes
@@ -42,7 +51,33 @@ Feature: Containers and landmarks
     When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
     Then it fails with the message:
       """
-      Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
+      Found 2 elements with <main> tag or role="main": /html/body/div[1] /html/body/div[2]
+      """
+
+  @html @automated
+  Scenario: Page has two main elements with <main> tags
+    Given a page with the body:
+      """
+      <main>Main one</main>
+      <main>Main two</main>
+      """
+    When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
+    Then it fails with the message:
+      """
+      Found 2 elements with <main> tag or role="main": /html/body/main[1] /html/body/main[2]
+      """
+
+  @html @automated
+  Scenario: Page has two main elements - 1 with <main> tag, 1 with role="main"
+    Given a page with the body:
+      """
+      <main>Main one</main>
+      <div role="main">Main two</div>
+      """
+    When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
+    Then it fails with the message:
+      """
+      Found 2 elements with <main> tag or role="main": /html/body/main /html/body/div
       """
 
   @html @automated
@@ -54,7 +89,19 @@ Feature: Containers and landmarks
     When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
     Then it fails with the message:
       """
-      Found 0 elements with role="main".
+      Found 0 elements with <main> tag or role="main".
+      """
+
+
+  Scenario: Page has zero main tags
+    Given a page with the body:
+      """
+      <div>Main one</div>
+      """
+    When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
+    Then it fails with the message:
+      """
+      Found 0 elements with <main> tag or role="main".
       """
 
   @html @manual

--- a/features/standards/mag/structure/03_containers_and_landmarks.feature
+++ b/features/standards/mag/structure/03_containers_and_landmarks.feature
@@ -16,7 +16,7 @@ Feature: Containers and landmarks
   HTML Applicability
   ==================
 
-  A page **must** have exactly one element with a <main> tag or `role="main"`
+  A page **must** have exactly one <main> tag or an element with `role="main"`
 
   The WAI-ARIA `main` landmark role can be help keyboard users with assistive
   technologies such as screen readers (and in the future as native browser

--- a/lib/standards/tests/exactlyOneMainLandmark.js
+++ b/lib/standards/tests/exactlyOneMainLandmark.js
@@ -3,17 +3,17 @@ module.exports = {
 
   type: 'automated',
 
-  failsForEach: 'page with no landmark element (any element with role="main")',
+  failsForEach: 'page with no main landmark element (<main> tag or any element with role="main")',
 
   topFrameOnly: true,
 
   test: function ({ $, fail }) {
-    var mainLandmarks = $("[role='main']")
+    var mainLandmarks = $("[role='main'], main")
     var count = mainLandmarks.length
     if (count === 0) {
-      fail('Found 0 elements with role="main".')
+      fail('Found 0 elements with <main> tag or role="main".')
     } else if (count > 1) {
-      fail('Found ' + count + ' elements with role="main":', mainLandmarks)
+      fail('Found ' + count + ' elements with <main> tag or role="main":', mainLandmarks)
     }
   }
 }

--- a/test/a11ySpec.js
+++ b/test/a11ySpec.js
@@ -30,13 +30,13 @@ describe('a11y', function () {
   })
 
   it('hides errors', function () {
-    return a11y.test({ hide: ['Found 0 elements with role="main".'] })
+    return a11y.test({ hide: ['Found 0 elements with <main> tag or role="main".'] })
       .then(function (outcome) {
         var resultsWithErrors = outcome.results.filter(function (standardResult) {
           return standardResult.hiddenErrors.length > 0
         })
         expect(resultsWithErrors[0].errors).to.eql([])
-        expect(resultsWithErrors[0].hiddenErrors).to.eql([['Found 0 elements with role="main".']])
+        expect(resultsWithErrors[0].hiddenErrors).to.eql([['Found 0 elements with <main> tag or role="main".']])
       })
   })
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->
This fix is to allow the "Exactly one main landmark" check to cater for the existence of a `<main>` tag _or_ an element with `role="main"`

## Details

<!--- Describe your changes in detail -->
I have updated the xpath which checks for existence of `role="main"` to also include a `main` tag 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
WebCore uses the `<main>` landmark, so bbc-a11y fails the "Structure: Containers and landmarks: Exactly one main landmark" check when running against pages on WebCore - e.g. https://www.bbc.co.uk (Home Page, Topics, SFV and more)

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/bbc/bbc-a11y/issues/320 

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->
I have updated the 03_containers_and_landmarks.feature to include new scenarios for the HTML containing `<main>` tags

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
