### PR TITLE
Update instructions to support M1 Macs

### DIFF
--- a/guides/using/checking-a-website.md
+++ b/guides/using/checking-a-website.md
@@ -9,6 +9,8 @@ Once you've downloaded node.js, you can open a terminal window and enter the
 following command:
 
     npm install bbc-a11y --global
+    
+Note: If using an Apple Silicon Mac (M1 etc), run the command ```npm install --arch=x64 electron@2.0.8``` for compatibility.
 
 ## Running bbc-a11y against your website
 


### PR DESCRIPTION
Updated the instructions to mention how to install with M1 Mac Compatibility.

## Motivation and Context

Make it easy to use bbc-a11y on modern M1 Macs.

## How Has This Been Tested?

Tested on an M1 Mac mini.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
