### PR TITLE
Allowing main element as well as main role

### DIFF
--- a/features/setting_cookies.feature
+++ b/features/setting_cookies.feature
@@ -28,11 +28,11 @@ Feature: Setting Cookies
 
       ✗ http://localhost:54321/good_with_cookie.html
         * Structure: Containers and landmarks: Exactly one main landmark
-          - Found 0 elements with role="main".
+          - Found 0 main elements (main or with role="main").
 
       ✗ http://localhost:54321/good_with_cookie.html
         * Structure: Containers and landmarks: Exactly one main landmark
-          - Found 0 elements with role="main".
+          - Found 0 main elements (main or with role="main").
 
       ✓ http://localhost:54321/good_with_cookie.html
       """

--- a/features/standards/mag/structure/03_containers_and_landmarks.feature
+++ b/features/standards/mag/structure/03_containers_and_landmarks.feature
@@ -24,10 +24,18 @@ Feature: Containers and landmarks
   navigation and other contents that might be before it.
 
   @html @automated
-  Scenario: Page has a single main element
+  Scenario: Page has a single element with role of main
     Given a page with the body:
       """
       <div role="main">Main element</div>
+      """
+    When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
+    Then it passes
+
+  Scenario: Page has a single main element
+    Given a page with the body:
+      """
+      <main>Main element</main>
       """
     When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
     Then it passes
@@ -42,7 +50,7 @@ Feature: Containers and landmarks
     When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
     Then it fails with the message:
       """
-      Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
+      Found 2 main elements (main or with role="main"): /html/body/div[1] /html/body/div[2]
       """
 
   @html @automated
@@ -54,7 +62,7 @@ Feature: Containers and landmarks
     When I test the "Structure: Containers and landmarks: Exactly one main landmark" standard
     Then it fails with the message:
       """
-      Found 0 elements with role="main".
+      Found 0 main elements (main or with role="main").
       """
 
   @html @manual

--- a/lib/standards/tests/exactlyOneMainLandmark.js
+++ b/lib/standards/tests/exactlyOneMainLandmark.js
@@ -8,12 +8,12 @@ module.exports = {
   topFrameOnly: true,
 
   test: function ({ $, fail }) {
-    var mainLandmarks = $("[role='main']")
+    var mainLandmarks = $("main,[role='main']")
     var count = mainLandmarks.length
     if (count === 0) {
-      fail('Found 0 elements with role="main".')
+      fail('Found 0 main elements (main or with role="main").')
     } else if (count > 1) {
-      fail('Found ' + count + ' elements with role="main":', mainLandmarks)
+      fail('Found ' + count + ' main elements (main or with role="main"):', mainLandmarks)
     }
   }
 }

--- a/test/a11ySpec.js
+++ b/test/a11ySpec.js
@@ -30,13 +30,13 @@ describe('a11y', function () {
   })
 
   it('hides errors', function () {
-    return a11y.test({ hide: ['Found 0 elements with role="main".'] })
+    return a11y.test({ hide: ['Found 0 main elements (main or with role="main").'] })
       .then(function (outcome) {
         var resultsWithErrors = outcome.results.filter(function (standardResult) {
           return standardResult.hiddenErrors.length > 0
         })
         expect(resultsWithErrors[0].errors).to.eql([])
-        expect(resultsWithErrors[0].hiddenErrors).to.eql([['Found 0 elements with role="main".']])
+        expect(resultsWithErrors[0].hiddenErrors).to.eql([['Found 0 main elements (main or with role="main").']])
       })
   })
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Allow `<main>` as well as <element role="main'> as this is even more valid.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Main_role
> The `<main>` element has a role of main.

## Details

Also changed message to that people are aware they can use the `<main>` element.

## Motivation and Context

NextJS uses a `<main>` element by default, but bbc-a11y does not like that there is no role="main"

## How Has This Been Tested?

Added/updated tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
