### PR TITLE
chore: fix license to add proper copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ file or class name and description of purpose be included on the
 same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright {yyyy} {name of copyright owner}
+Copyright 2016 British Broadcasting Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #341

**Description:**

As described in the issue, the license has boilerplate text still within it and it does not correctly identify the copyright holder.

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**

This change updates the copyright and holder to what it was before the new license change was made (6 years ago).
