### PR TITLE
fix: remove deprecated test functions

### DIFF
--- a/features/step_definitions/a11y_steps.js
+++ b/features/step_definitions/a11y_steps.js
@@ -101,12 +101,12 @@ When('I answer {string}', function (answer) {
 
 Then('the manual test fails', function () {
   return this.countAllErrors()
-    .then(count => assert.notEqual(count, 0))
+    .then(count => assert.notStrictEqual(count, 0))
 })
 
 Then('the manual test passes', function () {
   return this.countAllErrors()
-    .then(count => assert.equal(count, 0))
+    .then(count => assert.strictEqual(count, 0))
 })
 
 When('my page configuration is:', function (string) {
@@ -123,7 +123,7 @@ When('I test the {string} standard', function (name) {
 
 Then('it passes', function () {
   if ('exitCode' in this) {
-    assert.equal(this.exitCode, 0, '\n' + this.stdout + this.stderr)
+    assert.strictEqual(this.exitCode, 0, '\n' + this.stdout + this.stderr)
   } else {
     const resultsWithErrors = this.outcome.results.filter(function (result) {
       return result.errors.length > 0
@@ -146,7 +146,7 @@ Then('it passes with the warning:', function (message) {
       }).join(' ')
     }).join('\n')
   }).join('\n')
-  assert.equal(actualMessage, message)
+  assert.strictEqual(actualMessage, message)
 })
 
 Then('it should fail with:', function (expectedOutput) {
@@ -167,7 +167,7 @@ Then('it should fail with exactly:', function (expectedOutput) {
     console.log(sanitisedActualOutput)
     process.exit(1)
   }
-  assert.equal(sanitisedActualOutput, expectedOutput, 'Expected:\n' + expectedOutput.replace(/\n/g, '[\\n]\n') + '\nActual:\n' + sanitisedActualOutput.replace(/\n/g, '[\\n]\n'))
+  assert.strictEqual(sanitisedActualOutput, expectedOutput, 'Expected:\n' + expectedOutput.replace(/\n/g, '[\\n]\n') + '\nActual:\n' + sanitisedActualOutput.replace(/\n/g, '[\\n]\n'))
 })
 
 Then('it should pass with:', function (string) {
@@ -175,7 +175,7 @@ Then('it should pass with:', function (string) {
   if (actualOutput.indexOf(string) === -1) {
     throw new Error('Expected:\n' + string + '\nActual:\n' + actualOutput)
   }
-  assert.equal(this.exitCode, 0)
+  assert.strictEqual(this.exitCode, 0)
 })
 
 Then('it fails with the message:', function (message) {
@@ -188,11 +188,11 @@ Then('it fails with the message:', function (message) {
       }).join(' ')
     }).join('\n')
   }).join('\n')
-  assert.equal(actualMessage, message)
+  assert.strictEqual(actualMessage, message)
 })
 
 Then('the exit status should be {int}', function (status) {
-  assert.equal(this.exitCode, status)
+  assert.strictEqual(this.exitCode, status)
 })
 
 Then('the window should remain open', function () {
@@ -221,10 +221,10 @@ When('I answer all questions except one with a pass', function () {
 
 Then('it should result in a pass for {url}', function (url) {
   return this.countManualTestErrors(url)
-    .then(count => assert.equal(count, 0))
+    .then(count => assert.strictEqual(count, 0))
 })
 
 Then('it should result in a fail for {url}', function (url) {
   return this.countErrorsForUrl(url)
-    .then(count => assert.notEqual(count, 0))
+    .then(count => assert.notStrictEqual(count, 0))
 })

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -13,7 +13,7 @@ module.exports = {
       .option('-r, --reporter <reporter>', 'json or [path to custom reporter module]')
       .option('--coverage <list|table>', 'lists all tests with a description of each test')
       .parse(argv)
-      .opts();
+      .opts()
 
     return {
       interactive: !!opts.interactive,

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -18,7 +18,7 @@ module.exports = {
     return {
       interactive: !!opts.interactive,
       manual: !!opts.manual,
-      urls: commander.args, // remaining unprocessed arguments cab be found here
+      urls: commander.args, // remaining unprocessed arguments can be found here
       width: opts.width,
       configPath: opts.config,
       reporter: opts.reporter,

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -13,11 +13,12 @@ module.exports = {
       .option('-r, --reporter <reporter>', 'json or [path to custom reporter module]')
       .option('--coverage <list|table>', 'lists all tests with a description of each test')
       .parse(argv)
+      .opts();
 
     return {
       interactive: !!opts.interactive,
       manual: !!opts.manual,
-      urls: opts.args,
+      urls: commander.args, // remaining unprocessed arguments cab be found here
       width: opts.width,
       configPath: opts.config,
       reporter: opts.reporter,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bbc/a11y",
-  "version": "3.0.0-canary.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bbc/a11y",
-      "version": "3.0.0-canary.3",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "commander": "5.1.0",
+        "commander": "^7.2.0",
         "electron": "13.5.2",
         "jquery": "3.7.1"
       },
@@ -118,16 +118,6 @@
         "diff": "^4.0.1",
         "pad-right": "^0.2.2",
         "repeat-string": "^1.6.1"
-      }
-    },
-    "node_modules/@cucumber/cucumber/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@cucumber/cucumber/node_modules/diff": {
@@ -283,16 +273,6 @@
         "gherkin-javascript": "bin/gherkin"
       }
     },
-    "node_modules/@cucumber/gherkin-streams/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@cucumber/html-formatter": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-13.0.0.tgz",
@@ -306,16 +286,6 @@
       },
       "bin": {
         "cucumber-html-formatter": "bin/cucumber-html-formatter.js"
-      }
-    },
-    "node_modules/@cucumber/html-formatter/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@cucumber/message-streams": {
@@ -1462,12 +1432,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "generate-coverage": "./scripts/generate-coverage"
   },
   "dependencies": {
-    "commander": "^7.2.0",
+    "commander": "7.2.0",
     "electron": "13.5.2",
     "jquery": "3.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "generate-coverage": "./scripts/generate-coverage"
   },
   "dependencies": {
-    "commander": "5.1.0",
+    "commander": "^7.2.0",
     "electron": "13.5.2",
     "jquery": "3.7.1"
   },

--- a/test/commandLineArgsSpec.js
+++ b/test/commandLineArgsSpec.js
@@ -5,21 +5,21 @@ const assert = require('assert')
 describe('commandLineArgs.parse(argv)', function () {
   it('parses --width integer as viewport width', function () {
     const args = commandLineArgs.parse(['node', 'bbc-a11y', '--width', '777'])
-    assert.equal(777, args.width)
+    assert.strictEqual(777, args.width)
   })
 
   it('parses --interactive as a boolean', function () {
     const args = commandLineArgs.parse(['node', 'bbc-a11y', '--interactive'])
-    assert.equal(true, args.interactive)
+    assert.strictEqual(true, args.interactive)
   })
 
   it('parses --config as a string', function () {
     const args = commandLineArgs.parse(['node', 'bbc-a11y', '--config', 'foo'])
-    assert.equal('foo', args.configPath)
+    assert.strictEqual('foo', args.configPath)
   })
 
   it('parses all other arguments as URLs', function () {
     const args = commandLineArgs.parse(['node', 'bbc-a11y', 'foo', 'bar'])
-    assert.deepEqual(['foo', 'bar'], args.urls)
+    assert.deepStrictEqual(['foo', 'bar'], args.urls)
   })
 })

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -58,7 +58,7 @@ describe('configLoader.loadConfigFromPath(pathToConfigModule)', function () {
           throw new Error('Expected a rejection')
         })
         .catch(function (e) {
-          assert.equal("Unexpected token '>'", e.message)
+          assert.strictEqual("Unexpected token '>'", e.message)
         })
     })
   })
@@ -80,7 +80,7 @@ describe('configLoader.loadConfigFromPath(pathToConfigModule)', function () {
       it('resets page to its previous value', function () {
         return configLoader.loadConfigFromPath(pathToConfigModule('empty'))
           .then(function () {
-            assert.equal(666, global.page)
+            assert.strictEqual(666, global.page)
           })
       })
     })
@@ -89,10 +89,10 @@ describe('configLoader.loadConfigFromPath(pathToConfigModule)', function () {
       it('resets page to its previous value', function () {
         return configLoader.loadConfigFromPath(pathToConfigModule('syntaxError'))
           .then(function () {
-            assert.equal(666, global.page)
+            assert.strictEqual(666, global.page)
           })
           .catch(function () {
-            assert.equal(666, global.page)
+            assert.strictEqual(666, global.page)
           })
       })
     })

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -12,7 +12,7 @@ describe('configLoader.loadConfigFromPath(pathToConfigModule)', function () {
     it('resolves with a list of pages', function () {
       return configLoader.loadConfigFromPath(pathToConfigModule('simple'))
         .then(function (config) {
-          assert.deepEqual(config, {
+          assert.deepStrictEqual(config, {
             pages: [
               { url: 'https://www.bbc.co.uk' },
               { url: 'https://www.bbc.co.uk/news' }
@@ -26,7 +26,7 @@ describe('configLoader.loadConfigFromPath(pathToConfigModule)', function () {
     it('resolves with a list of pages', function () {
       return configLoader.loadConfigFromPath(pathToConfigModule('skipAndOnly'))
         .then(function (config) {
-          assert.deepEqual(config, {
+          assert.deepStrictEqual(config, {
             pages: [
               { url: 'https://www.bbc.co.uk', skip: ['x'] },
               { url: 'https://www.bbc.co.uk/news', skip: ['y', 'z'] },
@@ -42,7 +42,7 @@ describe('configLoader.loadConfigFromPath(pathToConfigModule)', function () {
     it('resolves with a list of pages', function () {
       return configLoader.loadConfigFromPath(pathToConfigModule('viewportWidth'))
         .then(function (config) {
-          assert.deepEqual(config, {
+          assert.deepStrictEqual(config, {
             pages: [
               { url: 'https://www.bbc.co.uk', width: 789 }
             ]

--- a/test/runnerSpec.js
+++ b/test/runnerSpec.js
@@ -79,8 +79,8 @@ describe('Runner', function () {
       return run([{ url: 'https://example.com/' }])
         .then(function (events) {
           const firstEventPayload = JSON.parse(events[0].args[0])
-          assert.deepEqual(firstEventPayload.pagesChecked, 1)
-          assert.deepEqual(events[events.length - 1], { type: 'exit', args: [1] })
+          assert.deepStrictEqual(firstEventPayload.pagesChecked, 1)
+          assert.deepStrictEqual(events[events.length - 1], { type: 'exit', args: [1] })
         })
     }).timeout(10000)
   })
@@ -91,8 +91,8 @@ describe('Runner', function () {
       return run([], configPath)
         .then(function (events) {
           const firstEventPayload = JSON.parse(events[0].args[0])
-          assert.deepEqual(firstEventPayload.pagesChecked, 2)
-          assert.deepEqual(events[events.length - 1], { type: 'exit', args: [1] })
+          assert.deepStrictEqual(firstEventPayload.pagesChecked, 2)
+          assert.deepStrictEqual(events[events.length - 1], { type: 'exit', args: [1] })
         })
     }).timeout(10000)
   })

--- a/test/sectionsSpec.js
+++ b/test/sectionsSpec.js
@@ -7,7 +7,7 @@ describe('Standards.sections', function () {
     const urls = {}
     for (const name in sections) {
       const section = sections[name]
-      assert.equal(typeof section.documentationUrl, 'string')
+      assert.strictEqual(typeof section.documentationUrl, 'string')
       if (urls[section.documentationUrl]) assert.fail('duplicate: ' + section.documentationUrl)
       urls[section.documentationUrl] = true
     }


### PR DESCRIPTION
Resolves #NUMBER

**Description:**
Upgraded Commander from v5 to v7
Updated deprecated test functions

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
Keeping changes up to date with latest testing lib versions

**Code changes:**

- Updated args.js to ensure Commander returns the correct config
- Replaced `.equal(` with `.strictEqual(`
- Replaced `.notEqual(` with `.notStrictEqual(`
- Replaced `.deepEqual(` with `.deepStrictEqual(`

---

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
